### PR TITLE
Refactor homepage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,21 @@
-.PHONY: help themes html serve clean
+.PHONY: help prepare html serve clean
 .DEFAULT_GOAL := help
 
-help:
-	@grep ": ##" Makefile | grep -v grep | tr -d '#'
+# Add help text after each target name starting with '\#\#'
+help:   ## show this help
+	@echo -e "Help for this makefile\n"
+	@echo "Possible commands are:"
+	@grep -h "##" $(MAKEFILE_LIST) | grep -v grep | sed -e 's/\(.*\):.*##\(.*\)/    \1: \2/'
 
-themes/scientific-python-hugo-theme:
-	@if [ ! -d "$<" ]; then \
-	  echo "*** ERROR: missing theme" ; \
-	  echo ; \
-	  echo "It looks as though you are missing the themes directory."; \
-	  echo "You need to add the scientific-python-hugo-theme as a submodule."; \
-	  echo ; \
-	  echo "Please see https://theme.scientific-python.org/getstarted/"; \
-	  echo ; \
-	  exit 1; \
-	fi
-
-themes: themes/scientific-python-hugo-theme
+prepare:
+	git submodule update --init
 
 html: ## Build site in `./public`
-html: themes
+html: prepare
 	hugo
 
 serve: ## Serve site, typically on http://localhost:1313
-serve: themes
+serve: prepare
 	@hugo --i18n-warnings server
 
 clean: ## Remove built files

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,16 @@
+.post-author:not(:first-child):before {
+  content: "";
+}
+
+.post-date {
+  padding-left: 0.5rem;
+}
+
+.post-author:not(:first-child) {
+  padding-left: 0.5rem;
+}
+
+.post-meta {
+  color: var(--colorSecondaryDark);
+  padding-bottom: 1rem;
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -6,6 +6,10 @@
   padding-left: 0.5rem;
 }
 
+.post-tag {
+  padding-left: 0.3rem;
+}
+
 .post-author:not(:first-child) {
   padding-left: 0.5rem;
 }

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,8 @@ languageCode: "en-us"
 title: "Scientific Python blog"
 theme: ["hugo-atom-feed", "scientific-python-hugo-theme"]
 relativeURLs: true
-disableKinds: ["RSS"]
+disableKinds: ["RSS", "taxonomy"]
+ignoreErrors: ["error-disable-taxonomy"]
 
 markup:
   highlight:
@@ -17,6 +18,10 @@ outputFormats:
 
 outputs:
   home: ["HTML", "ATOM"]
+
+permalinks:
+  # mimic pelican permalink configuration
+  /: "/:year/:month/:day/:slug/"
 
 params:
   description: "Posts from the Scientific Python community"

--- a/config.yaml
+++ b/config.yaml
@@ -46,9 +46,11 @@ params:
       - link: https://scientific-python.org
         icon: home
       - link: https://github.com/scientific-python/blog.scientific-python.org
-        icon: github
+        icon: fa-brands fa-github
       - link: https://blog.scientific-python.org/atom.xml
-        icon: atom
+        icon: fa-solid fa-square-rss
+      - link: https://discuss.scientific-python.org/
+        icon: fa-brands fa-discourse
     quicklinks:
       column2:
         links:

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ languageCode: "en-us"
 title: "Scientific Python blog"
 theme: ["hugo-atom-feed", "scientific-python-hugo-theme"]
 relativeURLs: true
-disableKinds: ["term", "taxonomy", "RSS"]
+disableKinds: ["RSS"]
 
 markup:
   highlight:
@@ -24,14 +24,12 @@ params:
   - /images/logo.svg
   navbarlogo:
     image: logo.svg
-    text: Scientific Python Hugo Theme
+    text: Scientific Python Blog
     link: /
   hero:
-    title: Scientific Python Theme
+    title: Scientific Python Blog
     image: logo.svg
   navbar:
-   - title: Blog
-     url: https://blog.scientific-python.org
    - title: RSS
      url: /atom.xml
    - title: About Scientific Python
@@ -42,8 +40,12 @@ params:
     logo: logo.svg
     socialmediatitle: ""
     socialmedia:
-      - link: https://github.com/scientific-python/
+      - link: https://scientific-python.org
+        icon: home
+      - link: https://github.com/scientific-python/blog.scientific-python.org
         icon: github
+      - link: https://blog.scientific-python.org/atom.xml
+        icon: atom
     quicklinks:
       column2:
         links:

--- a/config.yaml
+++ b/config.yaml
@@ -26,9 +26,6 @@ params:
     image: logo.svg
     text: Scientific Python Blog
     link: /
-  hero:
-    title: Scientific Python Blog
-    image: logo.svg
   navbar:
    - title: RSS
      url: /atom.xml

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,7 @@ outputFormats:
 
 outputs:
   home: ["HTML", "ATOM"]
+  term: ["HTML", "ATOM"]
 
 permalinks:
   # mimic pelican permalink configuration

--- a/content/2022-02-08-test/index.md
+++ b/content/2022-02-08-test/index.md
@@ -1,6 +1,9 @@
 ---
 title: This is a test blog post
 author: Stéfan van der Walt
+tags:
+    - tag1
+    - tag2
 ---
 
 Hi there, and welcome to the Scientific Python blog!

--- a/content/2022-02-08-test/index.md
+++ b/content/2022-02-08-test/index.md
@@ -1,6 +1,6 @@
 ---
 title: This is a test blog post
-author: Stéfan van der Walt
+author: ["Stéfan van der Walt"]
 tags:
     - tag1
     - tag2

--- a/content/2022-02-08-test/index.md
+++ b/content/2022-02-08-test/index.md
@@ -1,6 +1,7 @@
 ---
 title: This is a test blog post
-author: ["Stéfan van der Walt"]
+author: ["Stéfan van der Walt", "Pamphile Roy"]
+date: 2022-02-25
 tags:
     - tag1
     - tag2

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,0 +1,20 @@
+{{ define "navbar" }}
+{{ partial "navbar.html" . }}
+{{ end }}
+
+{{ define "main" }}
+<section class="content-padding flex-row">
+  <div class="content-container">
+    <h1 id="term-title">Posts with #{{ .Title }}</h1>
+    {{ range .Pages }}
+    <div class="post-list">
+      <article>
+        <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
+        {{ partial "post_meta.html" . }}
+        <div class="post-summary">{{ .Summary }}</div>
+      </article>
+    </div>
+    {{ end }}
+  </div>
+</section>
+{{ end }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -5,11 +5,18 @@
 {{ define "main" }}
 <section class="content-padding flex-row">
   <div class="content-container">
-    <h1 id="term-title">Posts with #{{ .Title }}</h1>
+    <h1 id="term-title">
+      Posts with
+        <a href="atom.xml">#{{ .Title }}
+          <span class="icon fas fa-rss" style="vertical-align: baseline;"></span>
+        </a>
+    </h1>
     {{ range .Pages }}
     <div class="post-list">
       <article>
-        <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
+        <div class="post-title">
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        </div>
         {{ partial "post_meta.html" . }}
         <div class="post-summary">{{ .Summary }}</div>
       </article>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,3 +1,7 @@
+{{ define "navbar" }}
+{{ partial "navbar.html" . }}
+{{ end }}
+
 {{ define "main" }}
-{{ partial "section/section.html" . }}
+{{ partial "section.html" . }}
 {{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,0 +1,55 @@
+{{- $title          := .Site.Params.title }}
+{{- $navbar         := .Site.Params.navbar }}
+{{- $navbarLogo     := .Site.Params.navbarlogo }}
+<nav id="nav" class="navbar is-fresh is-transparent no-shadow" role="navigation" aria-label="main navigation">
+  <div class="container is-max-widescreen">
+    <div class="navbar-brand">
+      {{- if $navbarLogo}}
+      <a id="navbar-item" class="navbar-item" href="{{ $navbarLogo.link }}">
+        <img id="navbar-logo" src="{{ printf "/images/%s" $navbarLogo.image | relURL }}" alt="{{ default (printf "%s logo" $title) $navbarLogo.altText }}">
+        <div id="navbar-logo-text">{{ default "" $navbarLogo.text }}</div>
+      </a>
+      {{- end}}
+
+      <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbar-menu">
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+        <span aria-hidden="true"></span>
+      </a>
+    </div>
+
+    <div id="navbar-menu" class="navbar-menu is-static">
+
+      <div class="navbar-end">
+        {{- range $navbar }}
+        {{- if .sublinks }}
+        <div id="navbar-item" class="navbar-item has-dropdown is-hoverable">
+          <a class="navbar-link">
+            {{ .title }}
+          </a>
+
+          <div class="navbar-dropdown">
+            {{- range .sublinks }}
+            <a href="{{ .url }}" id="navbar-item" class="navbar-item">
+              {{ .title }}
+            </a>
+            {{- end }}
+          </div>
+        </div>
+        {{- else if .button }}
+        <a href="{{ .url }}" id="navbar-item" class="navbar-item">
+          <span class="button signup-button rounded secondary-btn raised">
+            {{ .title }}
+          </span>
+        </a>
+        {{- else }}
+        <a href="{{ .url }}" id="navbar-item" class="navbar-item is-secondary">
+          {{ .title }}
+        </a>
+        {{- end }}
+        {{- end }}
+
+      </div>
+    </div>
+  </div>
+</nav>

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -5,6 +5,14 @@
     {{- end -}}
   </span>
   {{ if .Date }}
-  <span class="post-date"><span style="vertical-align: bottom;" class="icon fas  fa-calendar"></span> {{.Date.Format "January 2, 2006"}}</span>
+  <span class="post-date"><span style="vertical-align: bottom;" class="icon fas fa-calendar"></span> {{.Date.Format "January 2, 2006"}}</span>
   {{ end }}
+  {{- if .Params.tags -}}
+  <div class="post-tags">
+    <span style="vertical-align: bottom;" class="icon fas fa-tag"></span>
+    {{- range .Params.tags -}}
+    <span class="post-tag"><a href="{{ path.Join "/tags/" . | relURL }}">#{{.}}</a></span>
+    {{- end -}}
+  </div>
+  {{- end -}}
 </div>

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,8 +1,10 @@
-<span class="post-authors">
-  {{- range .Params.author -}}
-  <div class="post-author"><span style="vertical-align: bottom;" class="icon fa fa-user"></span> {{ . }}</div>
-  {{- end -}}
-</span>
-{{ if .Date }}
-<span class="post-date"><span style="vertical-align: bottom;" class="icon fas  fa-calendar"></span> {{.Date.Format "January 2, 2006"}}</span>
-{{ end }}
+<div class="post-meta">
+  <span class="post-authors">
+    {{- range .Params.author -}}
+    <div class="post-author"><span style="vertical-align: bottom;" class="icon fa fa-user"></span> {{ . }}</div>
+    {{- end -}}
+  </span>
+  {{ if .Date }}
+  <span class="post-date"><span style="vertical-align: bottom;" class="icon fas  fa-calendar"></span> {{.Date.Format "January 2, 2006"}}</span>
+  {{ end }}
+</div>

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -1,0 +1,8 @@
+<span class="post-authors">
+  {{- range .Params.author -}}
+  <div class="post-author"><span style="vertical-align: bottom;" class="icon fa fa-user"></span> {{ . }}</div>
+  {{- end -}}
+</span>
+{{ if .Date }}
+<span class="post-date"><span style="vertical-align: bottom;" class="icon fas  fa-calendar"></span> {{.Date.Format "January 2, 2006"}}</span>
+{{ end }}

--- a/layouts/partials/section.html
+++ b/layouts/partials/section.html
@@ -1,28 +1,13 @@
 <section class="content-padding flex-row">
-<div class="shortcuts-container">
-  <div class="shortcuts-title"><img src="/images/icons/mui-icons_format-list-bulleted.svg"/>On this page</div>
-  <div id="shortcuts"></div>
-</div>
 <div class="content-container">
-  {{ if .Content }}
-  {{ .Content }}
-  {{ else }}
   {{ range .Pages }}
   <div class="post-list">
     <article>
       <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
-      <div class="post-authors">
-        {{- range .Params.author -}}
-        <div class="post-author"><span style="vertical-align: bottom;" class="icon fa fa-user"></span> {{ . }}</div>
-        {{- end -}}
-      </div>
-      {{ if .Date }}
-      <div class="post-date"><span style="vertical-align: bottom;" class="icon fas  fa-calendar"></span> {{.Date.Format "January 2, 2006"}}</div>
-      {{ end }}
+      {{ partial "post_meta.html" . }}
       <div class="post-summary">{{ .Summary }}</div>
     </article>
   </div>
-  {{ end }}
   {{ end }}
 </div>
 </section>

--- a/layouts/partials/section.html
+++ b/layouts/partials/section.html
@@ -1,0 +1,28 @@
+<section class="content-padding flex-row">
+<div class="shortcuts-container">
+  <div class="shortcuts-title"><img src="/images/icons/mui-icons_format-list-bulleted.svg"/>On this page</div>
+  <div id="shortcuts"></div>
+</div>
+<div class="content-container">
+  {{ if .Content }}
+  {{ .Content }}
+  {{ else }}
+  {{ range .Pages }}
+  <div class="post-list">
+    <article>
+      <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
+      <div class="post-authors">
+        {{- range .Params.author -}}
+        <div class="post-author"><span style="vertical-align: bottom;" class="icon fa fa-user"></span> {{ . }}</div>
+        {{- end -}}
+      </div>
+      {{ if .Date }}
+      <div class="post-date"><span style="vertical-align: bottom;" class="icon fas  fa-calendar"></span> {{.Date.Format "January 2, 2006"}}</div>
+      {{ end }}
+      <div class="post-summary">{{ .Summary }}</div>
+    </article>
+  </div>
+  {{ end }}
+  {{ end }}
+</div>
+</section>


### PR DESCRIPTION
Todo in the theme repo:

- [x] missing banner / logo main page
- [x] missing atom feed icon
   S: Can fix once https://github.com/scientific-python/scientific-python-hugo-theme/pull/124 is merged
- [ ] missing home page icon
- [x] tags / categories / taxonomies
  S: added tags only for now
- [ ] missing blog post headers
   S: let's file this as an issue on the theme repo (it probably needs to be special cased for the news section, since we don't show authors on other pages)
  - should show up on news articles too:
  - [ ] https://deploy-preview-204--scientific-python-org.netlify.app/news/specs-announced-scipy2021/

Todo here:

- [ ] make example a numpy newletter example (add some code, add a diagram, ask Inessa for feedback)