### PR TITLE
Fix missing build requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 jupytext
 nbconvert
 ipykernel
+ipython-genutils
 
 # core packages
 # others can be installed inside of individual notebooks


### PR DESCRIPTION
Not sure what happened, but this morning the build failed with this error
```
7:09:01 AM: $ make html
7:09:01 AM: git submodule update --init
7:09:01 AM: jupytext content/2022-02-09-test-notebook/notebook.md -o content/2022-02-09-test-notebook/index.ipynb
7:09:02 AM: [jupytext] Reading content/2022-02-09-test-notebook/notebook.md in format md
7:09:02 AM: [jupytext] Writing content/2022-02-09-test-notebook/index.ipynb
7:09:02 AM: jupyter nbconvert --execute content/2022-02-09-test-notebook/index.ipynb --to markdown --TemplateExporter.extra_template_basedirs=. --template=mdoutput_template
7:09:02 AM: Traceback (most recent call last):
7:09:02 AM:   File "/opt/buildhome/python3.8/bin/jupyter-nbconvert", line 5, in <module>
7:09:02 AM:     from nbconvert.nbconvertapp import main
7:09:02 AM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/nbconvert/__init__.py", line 4, in <module>
7:09:02 AM:     from .exporters import *
7:09:02 AM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/nbconvert/exporters/__init__.py", line 3, in <module>
7:09:02 AM:     from .html import HTMLExporter
7:09:02 AM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/nbconvert/exporters/html.py", line 25, in <module>
7:09:02 AM:     from nbconvert.filters.highlight import Highlight2HTML
7:09:02 AM:   File "/opt/buildhome/python3.8/lib/python3.8/site-packages/nbconvert/filters/__init__.py", line 11, in <module>
7:09:02 AM:     from ipython_genutils.text import indent
7:09:02 AM: ModuleNotFoundError: No module named 'ipython_genutils'
7:09:02 AM: make: *** [Makefile:34: content/2022-02-09-test-notebook/index.md] Error 1
```

The relevant difference seem to be:

- nbclient-0.5.12 was upgraded to nbclient-0.5.13
- nbformat-5.1.3 was upgraded to nbformat-5.2.0

This also changed:
- fonttools-4.29.1 upgraded to fonttools-4.30.0