### PR TITLE
Use default pagination

### DIFF
--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -3,12 +3,10 @@
 {{ end }}
 
 {{ define "main" }}
-{{ $page := . }}
 <section class="content-padding flex-row">
 <div class="content-container">
-  {{ range $.Site.RegularPages }}
-  {{/* Only list blog posts; other pages do not have inferred dates */}}
-  {{ if .Params.Date }}
+  {{ $paginator := .Paginate (where $.Site.RegularPages.ByPublishDate.Reverse "Section" "posts") }}
+  {{ range $paginator.Pages }}
   <div class="post-list">
     <article>
       <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
@@ -19,7 +17,7 @@
     </article>
   </div>
   {{ end }}
-  {{ end }}
+  {{ template "_internal/pagination.html" . }}
 </div>
 </section>
 {{ end }}


### PR DESCRIPTION
This is the default and a bit ugly.  We should change it, but I would prefer adding the pagination now and fixing the look in a follow-up PR.

It also only shows pages in the `posts` directory and doesn't filter based on whether you have a date field anymore.