### PR TITLE
Quick review of GSoD 2022 proposal

### DIFF
--- a/content/posts/scientific-python/GSoD-2022-proposal/index.md
+++ b/content/posts/scientific-python/GSoD-2022-proposal/index.md
@@ -64,7 +64,7 @@ This project aims to:
 
 To ensure this project is successful, it is recommended that the technical
 writer has some familiarity with at least a few of Scientific Python's
-core projects (see https://scientific-python.org/specs/core-projects/ ).
+[core projects](https://scientific-python.org/specs/core-projects).
 
 ### Measuring your project’s success
 

--- a/content/posts/scientific-python/GSoD-2022-proposal/index.md
+++ b/content/posts/scientific-python/GSoD-2022-proposal/index.md
@@ -64,7 +64,7 @@ This project aims to:
 
 To ensure this project is successful, it is recommended that the technical
 writer has some familiarity with at least a few of Scientific Python's
-core projects (see https://scientific-python.org/specs/core-projects/).
+core projects (see https://scientific-python.org/specs/core-projects/ ).
 
 ### Measuring your project’s success
 


### PR DESCRIPTION
Fix a broken link to the core projects.

I had one other general comment - I think the individual scientific Python core projects should be explicitly mentioned and/or linked to in the `About your organization` section. If someone lands on this blog post without any context, it's not immediately clear what "scientific Python" means - adding mention of individual projects (numpy, scipy, matplotlib) or linking to the core projects page (or similar) would be helpful I think. 