### PR TITLE
Configure mathjax

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,10 +2,9 @@
 MathJax = {
   tex: {
     inlineMath: [['$', '$'], ['\\(', '\\)']],
-  },
-  loader: {load: ['ui/lazy']}
+  }
 };
 </script>
 <script type="text/javascript" id="MathJax-script" async
-  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/core.js">
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
 </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,12 @@
-<script type="text/javascript"
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script>
+MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']],
+    displayMath: [['$$','$$'], ['\\[', '\\]']],
+    processEscapes: true
+  }
+};
+</script>
+<script type="text/javascript" id="MathJax-script" async
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
 </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,10 +1,12 @@
-<script>
-MathJax = {
-  tex: {
-    inlineMath: [['$', '$'], ['\\(', '\\)']],
-  }
-};
-</script>
-<script type="text/javascript" id="MathJax-script" async
-  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
-</script>
+{{ if eq .Section "posts" }}
+    <script>
+      MathJax = {
+        tex: {
+          inlineMath: [['$', '$'], ['\\(', '\\)']],
+        }
+      };
+    </script>
+    <script type="text/javascript" id="MathJax-script" async
+      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+    </script>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,8 @@
 MathJax = {
   tex: {
     inlineMath: [['$', '$'], ['\\(', '\\)']],
-  }
+  },
+  loader: {load: ['ui/lazy']}
 };
 </script>
 <script type="text/javascript" id="MathJax-script" async

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,8 +2,6 @@
 MathJax = {
   tex: {
     inlineMath: [['$', '$'], ['\\(', '\\)']],
-    displayMath: [['$$','$$'], ['\\[', '\\]']],
-    processEscapes: true
   }
 };
 </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,5 +8,5 @@ MathJax = {
 };
 </script>
 <script type="text/javascript" id="MathJax-script" async
-  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
 </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,5 +7,5 @@ MathJax = {
 };
 </script>
 <script type="text/javascript" id="MathJax-script" async
-  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/core.js">
 </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,4 @@
-{{ if eq .Section "posts" }}
+{{ if  or (eq .Section "posts") (eq .Section "tags") }}
     <script>
       MathJax = {
         tex: {


### PR DESCRIPTION
We were using a retired CDN and mathjax 2.7:
- https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
- https://www.mathjax.org/cdn-shutting-down

I followed the instructions here:

- https://docs.mathjax.org/en/latest/web/configuration.html
- https://docs.mathjax.org/en/latest/options/input/tex.html

We can also configure the output.  For example,
- https://docs.mathjax.org/en/latest/options/input/tex.html