### PR TITLE
Use precommit CI bot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,8 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
+
+ci:
+  autofix_prs: false
+  autofix_commit_msg: "[pre-commit.ci 🤖] Apply code format tools to PR"
+  autoupdate_schedule: monthly


### PR DESCRIPTION
I've been adding the following text to the README:
```
### Precommit.ci Bot

We use the pre-commit CI bot to run linting tests and to auto fix pull requests. How it works:

- Pre-commit.ci will run the CI checks via a CI run in the PR.
- After the PR is approved but before it's merged, a maintainer can run the bot to apply linting fixes via a commit to the PR. To run the bot write:

`pre-commit.ci autofix` in a comment in the PR. This will trigger another CI run to double check that the linting / code style fixes are as expected. Then you can merge!

NOTE: the pre-commit CI bot CI action will allow you to see what checks pass. It will also remind you of the command to autofix the code in the pr.
```

Since the README here is pretty sparse, I wasn't sure where we should add this or whether we should expand the README to include development instructions like:
- https://github.com/scientific-python/scientific-python.org/blob/main/README.md