### PR TITLE
Fix mainpage

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -70,12 +70,3 @@ img.post-featuredImage {
   margin-top: 60px;
   padding-bottom: 10px;
 }
-
-.hero-title-content {
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  max-width: 1200px;
-  margin: 2vh auto;
-  justify-content: space-around;
-}

--- a/config.yaml
+++ b/config.yaml
@@ -46,24 +46,18 @@ params:
     text: Scientific Python Blog
     link: /
 
+  navbarlogoshow: true
+
   navbar:
     - title: Home
-      url: /
-      is_external: true
+      url: https://scientific-python.org
     - title: Blog
-      url: https://blog.scientific-python.org
-    - title: Devstats
-      url: https://devstats.scientific-python.org
-      is_external: true
+      url: /
     - title: Learn
       url: https://learn.scientific-python.org
-      is_external: true
-
-  hero:
-    title: Scientific Python Blog
-    image: logo.svg
 
   panel:
+    title: Posts from the Scientific Python community
     tiles:
       - buttonText: Submit a post
         url: /about/submit/

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,4 @@
 {{ define "main" }}
-    {{ if .Site.Params.hero }}
-    {{ partial "hero.html" . }}
-    {{ end }}
 {{ partial "panel.html" . }}
 {{ partial "section.html" . }}
 {{ end }}


### PR DESCRIPTION
This undoes https://github.com/scientific-python/blog.scientific-python.org/pull/48 which I did when I couldn't figure out how to do this. Depends on https://github.com/scientific-python/scientific-python-hugo-theme/pull/249.

This removes more custom code and relies more on the theme. There was an issue with a recent update to the theme that would have caused more customization here, which is why I decided to go back and remove the previous work around. I also never liked all the whitespace it put at the top of the site. It is now easier to see the content!