### PR TITLE
Update hugo (dark mode)

### DIFF
--- a/layouts/partials/section.html
+++ b/layouts/partials/section.html
@@ -3,7 +3,7 @@
 Recent Posts
 <div class="content-container">
   <!-- this section is populated by pulling posts from the site -->
-  {{ range first 5 (where $.Site.RegularPages.ByPublishDate.Reverse "Section" "posts") }}
+  {{ range first 7 (where $.Site.RegularPages.ByPublishDate.Reverse "Section" "posts") }}
   <div class="post-list">
     <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
     {{ partial "post_synopsis.html" . }}


### PR DESCRIPTION
There are several improvements/changes, but the main one is support for dark mode. There is no selector currently. It uses whatever your browser settings have selected. It also got rid of some empty white space, so I increased the number of posts displayed on the front page from 5 to 7.