### PR TITLE
Simplify two-column layout

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -78,24 +78,28 @@ div.MathJax_Display {
   padding-bottom: 10px;
 }
 
-/* Flex-column layout for /posts/. */
+.content-container .post-list {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 2rem;
+}
+
+/* Default: single column layout for mobile */
 .content-container {
   max-width: 70em;
   margin: 0 30px;
-}
-
-.content-container .flex-row {
-  justify-content: space-between;
   flex-direction: column;
 }
 
+/* Full screen two-column layout for desktop etc. */
 @media only screen and (min-width: 75em) {
-  .content-container .flex-row {
+  .content-container {
     flex-direction: row;
   }
-}
 
-.content-container .flex-row .post-list {
-  margin-left: 2em;
-  width: 100%;
+  article {
+    flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: calc(50% - 1rem);
+  }
 }

--- a/layouts/partials/posts.html
+++ b/layouts/partials/posts.html
@@ -1,26 +1,9 @@
 {{ $posts := . }}
-{{ range $k, $v := $posts }}
-{{ if (not (eq (mod $k 2) 0)) }}
-{{ continue }}
-{{ end }}
-{{ $first := $v }}
-{{ $second := index $posts (add $k 1) }}
-<div class="flex-row">
-  {{ with $first }}
-  <div class="post-list">
-    <article>
-      <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
-      <div>{{ partial "post_meta.html" (dict "context" . ) }}</div>
-    </article>
-  </div>
-  {{ end }}
-  {{ with $second }}
-  <div class="post-list">
-    <article>
-      <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
-      <div>{{ partial "post_meta.html" (dict "context" . ) }}</div>
-    </article>
-  </div>
+<div class="post-list">
+  {{ range $posts }}
+  <article>
+    <div class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></div>
+    <div>{{ partial "post_meta.html" (dict "context" . ) }}</div>
+  </article>
   {{ end }}
 </div>
-{{ end }}

--- a/layouts/partials/section.html
+++ b/layouts/partials/section.html
@@ -1,9 +1,8 @@
 <section class="content-padding flex-row">
   <div class="content-container">
-    Recent Posts
     {{- partial "posts.html" (first 8 (where $.Site.RegularPages.ByPublishDate.Reverse "Section" "posts")) -}}
     <div class="panel-box-action" style="text-align: left;">
-      <a class="panel-button" href="{{ "posts/" | relURL }}">All posts...</a>
+      <a class="panel-button" href="{{ "posts/" | relURL }}">Browse all posts &nbsp;⟶</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Instead of grouping posts in groups of HTML elements, use CSS: a wrapping flex container.

Also change the "All posts" button text to "Browse all posts".
