### PR TITLE
Add author link to numpy RNG post

### DIFF
--- a/content/authors/albertcthomas.md
+++ b/content/authors/albertcthomas.md
@@ -5,4 +5,4 @@ title: Albert Thomas
 👋 Hi!
 
 - My website is https://albertcthomas.github.io/
-- You can also find me on X/twitter at https://twitter.com/albertcthomas
+- You can also find me on X/Twitter at https://twitter.com/albertcthomas

--- a/content/authors/albertcthomas.md
+++ b/content/authors/albertcthomas.md
@@ -1,0 +1,8 @@
+---
+title: Albert Thomas
+---
+
+👋 Hi!
+
+- My website is https://albertcthomas.github.io/
+- You can also find me on X/twitter at https://twitter.com/albertcthomas

--- a/content/posts/numpy/numpy-rng/index.md
+++ b/content/posts/numpy/numpy-rng/index.md
@@ -7,7 +7,7 @@ Best Practices for Using NumPy's Random Number Generators
 "
 tags: [tutorials, numpy, rng]
 displayInList: true
-author: ["Albert Thomas"]
+author: ["Albert Thomas <albertcthomas>"]
 ---
 
 Given the practical challenges of achieving true randomness, deterministic algorithms, known as Pseudo Random Number Generators (RNGs), are employed in science to create sequences that mimic randomness. These generators are used for simulations, experiments, and analysis where it is essential to have numbers that appear unpredictable. I want to share here what I have learned about best practices with pseudo RNGs and especially the ones available in [NumPy](https://numpy.org/).


### PR DESCRIPTION
Adding author info to Numpy RNG blog post following  https://github.com/scientific-python/scientific-python-hugo-theme/pull/503

Thanks!