### PR TITLE
fix dates for atsp blog posts

### DIFF
--- a/content/posts/networkx/aTSP/a-closer-look-at-held-karp/index.md
+++ b/content/posts/networkx/aTSP/a-closer-look-at-held-karp/index.md
@@ -1,6 +1,6 @@
 ---
 title: "A Closer Look at the Held-Karp Relaxation"
-date: 2020-06-03
+date: 2021-06-03
 draft: false
 description: "Looking for a new method to solve the Held-Karp relaxation from the original Held and Karp paper"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/completing-the-asadpour-algorithm/index.md
+++ b/content/posts/networkx/aTSP/completing-the-asadpour-algorithm/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Completing the Asadpour Algorithm"
-date: 2020-08-10
+date: 2021-08-10
 draft: false
 description: "Implementation details for asadpour_atsp"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/entropy-distribution-setup/index.md
+++ b/content/posts/networkx/aTSP/entropy-distribution-setup/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Entropy Distribution Setup"
-date: 2020-07-13
+date: 2021-07-13
 draft: false
 description: "Preliminaries for the entropy distribution over spanning trees"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/entropy-distribution/index.md
+++ b/content/posts/networkx/aTSP/entropy-distribution/index.md
@@ -1,6 +1,6 @@
 ---
 title: "The Entropy Distribution"
-date: 2020-07-20
+date: 2021-07-20
 draft: false
 description: "Details on implementing the entropy distribution"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/finalizing-held-karp/index.md
+++ b/content/posts/networkx/aTSP/finalizing-held-karp/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Finalizing the Held-Karp Relaxation"
-date: 2020-07-07
+date: 2021-07-07
 draft: false
 description: "Picking which method to use for the final implementation of the Asadpour algorithm in NetworkX"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/finding-all-minimum-arborescences/index.md
+++ b/content/posts/networkx/aTSP/finding-all-minimum-arborescences/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Finding all Minimum Arborescences"
-date: 2020-06-05
+date: 2021-06-05
 draft: false
 description: "Exploring an algorithm to generate arborescences in ascending order"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/held-karp-relaxation/index.md
+++ b/content/posts/networkx/aTSP/held-karp-relaxation/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Held-Karp Relaxation"
-date: 2020-04-21
+date: 2021-04-21
 draft: false
 description: "Brief explanation of the Held-Karp relaxation and why it cannot be solved directly"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/held-karp-separation-oracle/index.md
+++ b/content/posts/networkx/aTSP/held-karp-separation-oracle/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Held-Karp Separation Oracle"
-date: 2020-05-08
+date: 2021-05-08
 draft: false
 description: "Considering creating a separation oracle for the Held-Karp relaxation"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/implementing-the-held-karp-relaxation/index.md
+++ b/content/posts/networkx/aTSP/implementing-the-held-karp-relaxation/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Implementing the Held-Karp Relaxation"
-date: 2020-06-28
+date: 2021-06-28
 draft: false
 description: "Implementation details for the ascent method to solve the Held-Karp relaxation"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/implementing-the-iterators/index.md
+++ b/content/posts/networkx/aTSP/implementing-the-iterators/index.md
@@ -1,6 +1,6 @@
 ---
 title: "implementing the Iterators"
-date: 2020-06-10
+date: 2021-06-10
 draft: false
 description: "Implementation details about SpanningTreeIterator and ArborescenceIterator"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/looking-at-the-big-picture/index.md
+++ b/content/posts/networkx/aTSP/looking-at-the-big-picture/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Looking at the Big Picture"
-date: 2020-07-29
+date: 2021-07-29
 draft: false
 description: "Prelimiaries for the final Asadpour algorithm function in NetworkX"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/my-summer-of-code-2021/index.md
+++ b/content/posts/networkx/aTSP/my-summer-of-code-2021/index.md
@@ -1,6 +1,6 @@
 ---
 title: "My Summer of Code 2021"
-date: 2020-08-16
+date: 2021-08-16
 draft: false
 description: "Review of my entire summer implementing the Asadpour ATSP Algorithm"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/networkx-function-stubs/index.md
+++ b/content/posts/networkx/aTSP/networkx-function-stubs/index.md
@@ -1,6 +1,6 @@
 ---
 title: "NetworkX Function Stubs"
-date: 2020-05-24
+date: 2021-05-24
 draft: false
 description: "Draft function stubs for the Asadpour method to use in the NetworkX API"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/preliminaries-for-sampling-a-spanning-tree/index.md
+++ b/content/posts/networkx/aTSP/preliminaries-for-sampling-a-spanning-tree/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Preliminaries for Sampling a Spanning Tree"
-date: 2020-07-21
+date: 2021-07-21
 draft: false
 description: "A close examination of the mathematics required to sample a random spanning tree from a graph"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/sampling-a-spanning-tree/index.md
+++ b/content/posts/networkx/aTSP/sampling-a-spanning-tree/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Sampling a Spanning Tree"
-date: 2020-07-28
+date: 2021-07-28
 draft: false
 description: "Implementation details for sample_spanning_tree"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]

--- a/content/posts/networkx/aTSP/understanding-the-ascent-method/index.md
+++ b/content/posts/networkx/aTSP/understanding-the-ascent-method/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Understanding the Ascent Method"
-date: 2020-06-22
+date: 2021-06-22
 draft: false
 description: "A deep dive into the ascent method for the Held-Karp relaxation"
 tags: ["gsoc", "networkx", "traveling-salesman-problem"]


### PR DESCRIPTION
Hello, 

Apparently when I moved the blog posts over two years ago, I dated them for 2020 by mistake but my summer of code was actually in 2021. I only noticed that now as I'm updating my own personal website. Should be a quick fix, but I don't know how I didn't notice originally. 
