### PR TITLE
Fix aTSP math rendering

### DIFF
--- a/content/posts/networkx/aTSP/a-closer-look-at-held-karp/index.md
+++ b/content/posts/networkx/aTSP/a-closer-look-at-held-karp/index.md
@@ -36,19 +36,19 @@ The Held and Karp paper discusses three methods for solving the relaxation:
 But before we explore the methods that Held and Karp discuss, we need to ensure that these methods still apply to solving the Held-Karp relaxation within the context of the Asadpour paper.
 The definition of the Held-Karp relaxation that I have been using on this blog comes from the Asadpour paper, section 3 and is listed below.
 
-\\[
+$$
 \begin{array}{c l l}
 \text{min} & \sum\_{a} c(a)x\_a \\\\\\
 \text{s.t.} & x(\delta^+(U)) \geqslant 1 & \forall\ U \subset V \text{ and } U \not= \emptyset \\\\\\
 & x(\delta^+(v)) = x(\delta^-(v)) = 1 & \forall\ v \in V \\\\\\
 & x\_a \geqslant 0 & \forall\ a
 \end{array}
-\\]
+$$
 
 The closest match to this program in the Held Karp paper is their linear program 3, which is a linear programming representation of the entire traveling salesman problem, not solely the relaxed version.
 Note that Held and Karp were dealing with the symmetric TSP (STSP) while Asadpour is addressing the asymmetric or directed TSP (ATSP).
 
-\\[
+$$
 \begin{array}{c l l}
 \text{min} & \sum\_{1 \leq i < j \leq n} c\_{i j}x\_{i j} \\\\\\
 \text{s.t.} & \sum\_{j > i} x\_{i j} + \sum\_{j < i} x\_{j i} = 2 & (i = 1, 2, \dots, n) \\\\\\
@@ -56,17 +56,17 @@ Note that Held and Karp were dealing with the symmetric TSP (STSP) while Asadpou
 & 0 \leq x\_{i j} \leq 1 & (1 \leq i < j \leq n) \\\\\\
 & x\_{i j} \text{integer} \\\\\\
 \end{array}
-\\]
+$$
 
 The last two constraints on the second linear program is correctly bounded and fits within the scope of the original problem while the first two constraints do most of the work in finding a TSP tour.
-Additionally, changing the last two constraints to be \\(x\_{i j} \geq 0\\) _is_ the Held Karp relaxation.
-The first constraint, \\(\sum\_{j > i} x\_{i j} + \sum\_{j < i} x\_{j i} = 2\\), ensures that for every vertex in the resulting tour there is one edge to get there and one edge to leave by.
+Additionally, changing the last two constraints to be $x\_{i j} \geq 0$ _is_ the Held Karp relaxation.
+The first constraint, $\sum\_{j > i} x\_{i j} + \sum\_{j < i} x\_{j i} = 2$, ensures that for every vertex in the resulting tour there is one edge to get there and one edge to leave by.
 This matches the second constraint in the Asadpour ATSP relaxation.
 The second constraint in the Held Karp formulation is another form of the subtour elimination constraint seen in the Asadpour linear program.
 
 Held and Karp also state that
 
-> In this section, we show that minimizing the gap \\(f(\pi)\\) is equivalent to solving this program _without_ the integer constraints.
+> In this section, we show that minimizing the gap $f(\pi)$ is equivalent to solving this program _without_ the integer constraints.
 
 on page 1141, so it would appear that solving one of the equivalent programs that Held and Karp forumalate should work here.
 
@@ -74,132 +74,132 @@ on page 1141, so it would appear that solving one of the equivalent programs tha
 
 The Column Generation technique seeks to solve linear program 2 from the Held and Karp paper, stated as
 
-\\[
+$$
 \begin{array}{c l}
 \text{min} & \sum\_{k} c\_ky\_k \\\\\\
 \text{s.t.} & y\_k \geq 0 \\\\\\
 & \sum\_k y\_k = 1 \\\\\\
 & \sum\_{i = 2}^{n - 1} (-v\_{i k})y\_k = 0 \\\\\\
 \end{array}
-\\]
+$$
 
-Where \\(v\_{i k}\\) is the degree of vertex \\(i\\) in 1-Tree \\(k\\) minus two, or \\(v\_{i k} = d\_{i k} - 2\\) and each variable \\(y_k\\) corresponds to a 1-Tree \\(T^k\\).
-The associated cost \\(c_k\\) for each tree is the weight of \\(T^k\\).
+Where $v\_{i k}$ is the degree of vertex $i$ in 1-Tree $k$ minus two, or $v\_{i k} = d\_{i k} - 2$ and each variable $y_k$ corresponds to a 1-Tree $T^k$.
+The associated cost $c_k$ for each tree is the weight of $T^k$.
 
 The rest of this method uses a simplex algorithm to solve the linear program.
 We only focus on the edges which are in each of the 1-Trees, giving each column the form
 
-\\[
+$$
 \begin{bmatrix}
 1 & -v\_{2k} & -v\_{3k} & \dots & -v\_{n-1,k}
 \end{bmatrix}^T
-\\]
+$$
 
-and the column which enters the solution in the 1-Tree for which \\(c_k + \theta + \sum\_{j=2}^{n-1} \pi_jv\_{j k}\\) is a minimum where \\(\theta\\) and \\(\pi_j\\) come from the vector of 'shadow prices' given by \\((\theta, \pi_2, \pi_3, \dots, \pi\_{n-1})\\).
-Now the basis is \\((n - 1) \times (n - 1)\\) and we can find the 1-Tree to add to the basis using a minimum 1-Tree algorithm which Held and Karp say can be done in \\(O(n^2)\\) steps.
+and the column which enters the solution in the 1-Tree for which $c_k + \theta + \sum\_{j=2}^{n-1} \pi_jv\_{j k}$ is a minimum where $\theta$ and $\pi_j$ come from the vector of 'shadow prices' given by $(\theta, \pi_2, \pi_3, \dots, \pi\_{n-1})$.
+Now the basis is $(n - 1) \times (n - 1)$ and we can find the 1-Tree to add to the basis using a minimum 1-Tree algorithm which Held and Karp say can be done in $O(n^2)$ steps.
 
 I am already [familiar](https://github.com/mjschwenne/GraphAlgorithms/blob/main/src/Simplex.py) with the simplex method, so I will not detail it's implementation here.
 
 ### Performance of the Column Generation Technique
 
 This technique is slow to converge.
-Held and Karp programmed in on an IBM/360 and where able to solve problems consestinal for up to \\(n = 12\\).
+Held and Karp programmed in on an IBM/360 and where able to solve problems consestinal for up to $n = 12$.
 Now, on a modern computer the clock rate is somewhere between 210 and 101,500 times faster (depending on the model of IBM/360 used), so we expect better performance, but cannot say at this time how much of an improvement.
 
 They also talk about a heuristic procedure in which a vertex is eliminated from the program whenever the choice of its adjacent vertices was 'evident'.
 Technical details for the heuristic where essentially non-existent, but
 
-> The procedure showed promise on examples up to \\(n = 48\\), but was not explored systematically
+> The procedure showed promise on examples up to $n = 48$, but was not explored systematically
 
 ## Ascent Method
 
-This paper from Held and Karp is about minimizing \\(f(\pi)\\) where \\(f(\pi)\\) is the gap between the permuted 1-Trees and a TSP tour.
-One way to do this is to maximize the dual of \\(f(\pi)\\) which is written as \\(\text{max}\_{\pi}\ w(\pi)\\) where
+This paper from Held and Karp is about minimizing $f(\pi)$ where $f(\pi)$ is the gap between the permuted 1-Trees and a TSP tour.
+One way to do this is to maximize the dual of $f(\pi)$ which is written as $\text{max}\_{\pi}\ w(\pi)$ where
 
-\\[
+$$
 w(\pi) = \text{min}\_k\ (c\_k + \sum\_{i=1}^{i=n} \pi\_iv\_{i k})
-\\]
+$$
 
-This method uses the set of indices of 1-Trees that are of minimum weight with respect to the weights \\(\overline{c}\_{i j} = c\_{i j} + \pi_i + \pi_j\\).
+This method uses the set of indices of 1-Trees that are of minimum weight with respect to the weights $\overline{c}\_{i j} = c\_{i j} + \pi_i + \pi_j$.
 
-\\[
+$$
 K(\pi) = \{k\ |\ w(\pi) = c\_k + \sum\_{i=1}^{i=n} \pi\_i v\_{i k}\}
-\\]
+$$
 
-If \\(\pi\\) is not a maximum point of \\(w\\), then there will be a vector \\(d\\) called the direction of ascent at \\(\pi\\).
+If $\pi$ is not a maximum point of $w$, then there will be a vector $d$ called the direction of ascent at $\pi$.
 This is theorem 3 and a proof is given on page 1148.
-Let the functions \\(\Delta(\pi, d)\\) and \\(K(\pi, d)\\) be defined as below.
+Let the functions $\Delta(\pi, d)$ and $K(\pi, d)$ be defined as below.
 
-\\[
+$$
 \Delta(\pi, d) = \text{min}\_{k \in K(\pi)}\ \sum\_{i=1}^{i=n} d\_iv\_{i k} \\\\\\
 K(\pi, d) = \{k\ |\ k \in K(\pi) \text{ and } \sum\_{i=1}^{i=n} d\_iv\_{i k} = \Delta(\pi, d)\}
-\\]
+$$
 
-Now for a sufficiently small \\(\epsilon\\), \\(K(\pi + \epsilon d) = K(\pi, d)\\) and \\(w(\pi + \epsilon d) = w(\pi) + \epsilon \Delta(\pi, d)\\), or the value of \\(w(\pi)\\) increases and the growth rate of the minimum 1-Trees is at its smallest so we maintain the low weight 1-Trees and progress farther towards the optimal value.
-Finally, let \\(\epsilon(\pi, d)\\) be the following quantity
+Now for a sufficiently small $\epsilon$, $K(\pi + \epsilon d) = K(\pi, d)$ and $w(\pi + \epsilon d) = w(\pi) + \epsilon \Delta(\pi, d)$, or the value of $w(\pi)$ increases and the growth rate of the minimum 1-Trees is at its smallest so we maintain the low weight 1-Trees and progress farther towards the optimal value.
+Finally, let $\epsilon(\pi, d)$ be the following quantity
 
-\\[
+$$
 \epsilon(\pi, d) = \text{max}\ \{\epsilon\ |\text{ for } \epsilon' < \epsilon,\ K(\pi + \epsilon'd = K(\pi, d)\}
-\\]
+$$
 
-So in other words, \\(\epsilon(\pi, d)\\) is the maximum distance in the direction of \\(d\\) that we can travel to maintain the desired behavior.
+So in other words, $\epsilon(\pi, d)$ is the maximum distance in the direction of $d$ that we can travel to maintain the desired behavior.
 
-If we can find \\(d\\) and \\(\epsilon\\) then we can set \\(\pi = \pi + \epsilon d\\) and move to the next iteration of the ascent method.
-Held and Karp did give a protocol for finding \\(d\\) on page 1149.
+If we can find $d$ and $\epsilon$ then we can set $\pi = \pi + \epsilon d$ and move to the next iteration of the ascent method.
+Held and Karp did give a protocol for finding $d$ on page 1149.
 
-1. Set \\(d\\) equal to the zero \\(n\\)-vector.
-2. Find a 1-tree \\(T^k\\) such that \\(k \in K(\pi, d)\\).
-3. If \\(\sum\_{i=1}^{i=n} d_iv\_{i k} > 0\\) STOP.
-4. \\(d_i \leftarrow d_i + v\_{i k},\\) for \\(i = 2, 3, \dots, n\\)
+1. Set $d$ equal to the zero $n$-vector.
+2. Find a 1-tree $T^k$ such that $k \in K(\pi, d)$.
+3. If $\sum\_{i=1}^{i=n} d_iv\_{i k} > 0$ STOP.
+4. $d_i \leftarrow d_i + v\_{i k},$ for $i = 2, 3, \dots, n$
 5. GO TO 2.
 
 There are two things which must be refined about this procedure in order to make it implementable in Python.
 
 - How do we find the 1-Tree mentioned in step 2?
-- How do we know when there is no direction of ascent? (i.e. how do we know when we are at the maximal value of \\(w(\pi)\\)?)
+- How do we know when there is no direction of ascent? (i.e. how do we know when we are at the maximal value of $w(\pi)$?)
 
 Held and Karp have provided guidance on both of these points.
 In section 6 on matroids, we are told to use a method developed by Dijkstra in _A Note on Two Problems in Connexion with Graphs_, but in this particular case that is not the most helpful.
 I have found this document, but there is a function called [`minimum_spanning_arborescence`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.tree.branchings.minimum_spanning_arborescence.html) already within NetworkX which we can use to create a minimum 1-Arborescence.
-That process would be to find a minimum spanning arborescence on only the vertices in \\(\{2, 3, \dots, n\}\\) and then connect vertex 1 to create the cycle.
+That process would be to find a minimum spanning arborescence on only the vertices in $\{2, 3, \dots, n\}$ and then connect vertex 1 to create the cycle.
 In order to connect vertex 1, we would choose the outgoing arc with the smallest cost and the incoming arc with the smallest cost.
 
-Finally, at the maximum value of \\(w(\pi)\\), there is no direction of ascent and the procedure outlined by Held and Karp will not terminate.
+Finally, at the maximum value of $w(\pi)$, there is no direction of ascent and the procedure outlined by Held and Karp will not terminate.
 Their article states on page 1149 that
 
-> Thus, when failure to terminate is suspected, it is necessary to check whether no direction of ascent exists; by the Minkowski-Farkas lemma this is equivalent to the existence of nonnegative coefficients \\(\alpha_k\\) such that
+> Thus, when failure to terminate is suspected, it is necessary to check whether no direction of ascent exists; by the Minkowski-Farkas lemma this is equivalent to the existence of nonnegative coefficients $\alpha_k$ such that
 >
-> \\( \sum\_{k \in K(\pi)} \alpha_kv\_{i k} = 0, \quad i = 1, 2, \dots, n \\)
+> $ \sum\_{k \in K(\pi)} \alpha_kv\_{i k} = 0, \quad i = 1, 2, \dots, n $
 >
 > This can be checked by linear programming.
 
 While it is nice that they gave that summation, the rest of the linear program would have been useful too.
 The entire linear program would be written as follows
 
-\\[
+$$
 \begin{array}{c l l}
 \text{max} & \sum\_k \alpha\_k \\\\\\
 \text{s.t.} & \sum\_{k \in K(\pi)} \alpha\_k v\_{i k} = 0 & \forall\ i \in \{1, 2, \dots n\} \\\\\\
 & \alpha\_k \geq 0 & \forall\ k \\\\\\
 \end{array}
-\\]
+$$
 
 This linear program is not in standard form, but it is not difficult to convert it.
 First, change the maximization to a minimization by minimizing the negative.
 
-\\[
+$$
 \begin{array}{c l l}
 \text{min} & \sum\_k -\alpha\_k \\\\\\
 \text{s.t.} & \sum\_{k \in K(\pi)} \alpha\_k v\_{i k} = 0 & \forall\ i \in \{1, 2, \dots n\} \\\\\\
 & \alpha\_k \geq 0 & \forall\ k \\\\\\
 \end{array}
-\\]
+$$
 
 While the constraint is not intuitively in standard form, a closer look reveals that it is.
-Each column in the matrix form will be for one entry of \\(\alpha_k\\), and each row will represent a different value of \\(i\\), or a different vertex.
+Each column in the matrix form will be for one entry of $\alpha_k$, and each row will represent a different value of $i$, or a different vertex.
 The one constraint is actually a collection of very similar one which could be written as
 
-\\[
+$$
 \begin{array}{c l}
 \text{min} & \sum\_k -\alpha\_k \\\\\\
 \text{s.t.} & \sum\_{k \in K(\pi)} \alpha\_k v\_{1 k} = 0 \\\\\\
@@ -208,11 +208,11 @@ The one constraint is actually a collection of very similar one which could be w
 & \sum\_{k \in K(\pi)} \alpha\_k v\_{n k} = 0 \\\\\\
 & \alpha\_k \geq 0 & \forall\ k \\\\\\
 \end{array}
-\\]
+$$
 
-Because all of the summations must equal zero, no stack and surplus variables are required, so the constraint matrix for this program is \\(n \times k\\).
-The \\(n\\) obviously has a linear growth rate, but I'm not sure how big to expect \\(k\\) to become.
-\\(k\\) is the set of minimum 1-Trees, so I believe that it will be manageable.
+Because all of the summations must equal zero, no stack and surplus variables are required, so the constraint matrix for this program is $n \times k$.
+The $n$ obviously has a linear growth rate, but I'm not sure how big to expect $k$ to become.
+$k$ is the set of minimum 1-Trees, so I believe that it will be manageable.
 This linear program can be solved using the built in [`linprog`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linprog.html) function in the SciPy library.
 
 As an implementation note, to start with I would probably check the terminating condition every iteration, but eventually we can find a number of iterations it has to execute before it starts to check for the terminating condition to save computational power.
@@ -221,24 +221,24 @@ One possible difficulty with the terminating condition is that we need to run th
 There does not seem to be an easy way to do this within NetworkX at the moment.
 Looking through the tree algorithms [here](https://networkx.org/documentation/stable/reference/algorithms/tree.html) they seem exclusively focused on finding _one_ minimum branching of the required type and not _all_ of those branchings.
 
-Now we have to find \\(\epsilon\\).
+Now we have to find $\epsilon$.
 Theorem 4 on page 1150 states that
 
-> Let \\(k\\) be any element of \\(K(\pi, d)\\), where \\(d\\) is a direction of ascent at \\(\pi\\).
+> Let $k$ be any element of $K(\pi, d)$, where $d$ is a direction of ascent at $\pi$.
 > Then
-> \\(\epsilon(\pi, d) = \text{min}\{\epsilon\ |\text{ for some pair } (e, e'),\ e' \text{ is a substitute for } e \text{ in } T^k \\\\\\ \text{ and } e \text{ and } e' \text{ cross over at } \epsilon \}\\)
+> $\epsilon(\pi, d) = \text{min}\{\epsilon\ |\text{ for some pair } (e, e'),\ e' \text{ is a substitute for } e \text{ in } T^k \\\\\\ \text{ and } e \text{ and } e' \text{ cross over at } \epsilon \}$
 
-The first step then is to determine if \\(e\\) and \\(e'\\) are substitutes.
-\\(e'\\) is a substitute if for a 1-Tree \\(T^k\\), \\((T^k - \{e\}) \cup \{e'\}\\) is also a 1-Tree.
-The edges \\(e = \{r, s\}\\) and \\(e' = \{i, j\}\\) cross over at \\(\epsilon\\) if the pairs \\((\overline{c}\_{i j}, d_i + d_j)\\) and \\((\overline{c}\_{r s}, d_r + d_s)\\) are different but
+The first step then is to determine if $e$ and $e'$ are substitutes.
+$e'$ is a substitute if for a 1-Tree $T^k$, $(T^k - \{e\}) \cup \{e'\}$ is also a 1-Tree.
+The edges $e = \{r, s\}$ and $e' = \{i, j\}$ cross over at $\epsilon$ if the pairs $(\overline{c}\_{i j}, d_i + d_j)$ and $(\overline{c}\_{r s}, d_r + d_s)$ are different but
 
-\\[
+$$
 \overline{c}\_{i j} + \epsilon(d\_i + d\_j) = \overline{c}\_{r s} + \epsilon(d\_r + d\_s)
-\\]
+$$
 
-From that equation, we can derive a formula for \\(\epsilon\\).
+From that equation, we can derive a formula for $\epsilon$.
 
-\\[
+$$
 \begin{array}{r c l}
 \overline{c}\_{i j} + \epsilon(d\_i + d\_j) &=& \overline{c}\_{r s} + \epsilon(d\_r + d\_s) \\\\\\
 \epsilon(d\_i + d\_j) &=& \overline{c}\_{r s} + \epsilon(d\_r + d\_s) - \overline{c}\_{i j} \\\\\\
@@ -247,17 +247,17 @@ From that equation, we can derive a formula for \\(\epsilon\\).
 \epsilon(d\_i + d\_j - d\_r - d\_s) &=& \overline{c}\_{r s} - \overline{c}\_{i j} \\\\\\
 \epsilon &=& \displaystyle \frac{\overline{c}\_{r s} - \overline{c}\_{i j}}{d\_i + d\_j - d\_r - d\_s}
 \end{array}
-\\]
+$$
 
-So we can now find \\(epsilon\\) for any two pairs of edges which are substitutes for each other, but we need to be able to find substitutes in the 1-Tree.
-We know that \\(e'\\) is a substitute for \\(e\\) if and only if \\(e\\) and \\(e'\\) are both incident to vertex 1 or \\(e\\) is in a cycle of \\(T^k \cup \{e'\}\\) that does not pass through vertex 1.
-In a more formal sense, we are trying to find edges in the same fundamental cycle as \\(e'\\).
+So we can now find $epsilon$ for any two pairs of edges which are substitutes for each other, but we need to be able to find substitutes in the 1-Tree.
+We know that $e'$ is a substitute for $e$ if and only if $e$ and $e'$ are both incident to vertex 1 or $e$ is in a cycle of $T^k \cup \{e'\}$ that does not pass through vertex 1.
+In a more formal sense, we are trying to find edges in the same fundamental cycle as $e'$.
 A fundamental cycle is created when any edge not in a spanning tree is added to that spanning tree.
 Because the endpoints of this edge are connected by one, unique path this creates a unique cycle.
 In order to find this cycle, we will take advantage of [`find_cycle`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.cycles.find_cycle.html) within the NetworkX library.
 
-Below is a pseudocode procedure that uses Theorem 4 to find \\(\epsilon(\pi, d)\\) that I sketched out.
-It is not well optimized, but will find \\(\epsilon(\pi, d)\\).
+Below is a pseudocode procedure that uses Theorem 4 to find $\epsilon(\pi, d)$ that I sketched out.
+It is not well optimized, but will find $\epsilon(\pi, d)$.
 
 ```
 # Input: An element k of K(pi, d), the vector pi and the vector d.
@@ -283,7 +283,7 @@ return min_epsilon
 
 The ascent method is also slow, but would be better on a modern computer.
 When Held and Karp programmed it, they tested it on some small problems up to 25 vertices and while the time per iteration was small, the number of iterations grew quickly.
-They do not comment on if this is a better method than the Column Generation technique, but do point up that they did not determine if this method _always_ converges to a maximum point of \\(w(\pi)\\).
+They do not comment on if this is a better method than the Column Generation technique, but do point up that they did not determine if this method _always_ converges to a maximum point of $w(\pi)$.
 
 ## Branch and Bound Method
 
@@ -292,97 +292,97 @@ The ascent method is embedded within this method, so the in depth exploration of
 Most of the notation in this method is reused from the ascent method.
 
 The branch and bound method utilizes the concept that a vertex can be out-of-kilter.
-A vertex \\(i\\) is out-of-kilter high if
+A vertex $i$ is out-of-kilter high if
 
-\\[
+$$
 \forall\ k \in K(\pi),\ v\_{i k} \geq 1
-\\]
+$$
 
-Similarly, vertex \\(i\\) is out-of-kilter low if
+Similarly, vertex $i$ is out-of-kilter low if
 
-\\[
+$$
 \forall\ k \in K(\pi),\ v\_{i k} = -1
-\\]
+$$
 
-Remember that \\(v\_{i k}\\) is the degree of the vertex minus 2.
-We know that all the vertices have a degree of at least one, otherwise the 1-Tree \\(T^k\\) would not be connected.
+Remember that $v\_{i k}$ is the degree of the vertex minus 2.
+We know that all the vertices have a degree of at least one, otherwise the 1-Tree $T^k$ would not be connected.
 An out-of-kilter high vertex has a degree of 3 or higher in every minimum 1-Tree and an out-of-kilter low vertex has a degree of only one in all of the minimum 1-Trees.
 Our goal is a minimum 1-Tree where every vertex has a degree of 2.
 
 If we know that a vertex is out-of-kilter in either direction, we know the direction of ascent and that direction is a unit vector.
-Let \\(u_i\\) be an \\(n\\)-dimensional unit vector with 1 in the \\(i\\)-th coordinate.
-\\(u_i\\) is the direction of ascent if vertex \\(i\\) is out-of-kilter high and \\(-u_i\\) is the direction of ascent if vertex \\(i\\) is out-of-kilter low.
+Let $u_i$ be an $n$-dimensional unit vector with 1 in the $i$-th coordinate.
+$u_i$ is the direction of ascent if vertex $i$ is out-of-kilter high and $-u_i$ is the direction of ascent if vertex $i$ is out-of-kilter low.
 
-Corollaries 3 and 4 from page 1151 also show that finding \\(\epsilon(\pi, d)\\) is simpler when a vertex is out-of-kilter as well.
+Corollaries 3 and 4 from page 1151 also show that finding $\epsilon(\pi, d)$ is simpler when a vertex is out-of-kilter as well.
 
-> _Corollary 3._ Assume vertex \\(i\\) is out-of-kilter low and let \\(k\\) be an element of \\(K(\pi, -u_i)\\).
-> Then \\(\epsilon(\pi, -u_i) = \text{min} (\overline{c}\_{i j} - \overline{c}\_{r s})\\) such that \\(\{i, j\}\\) is a substitute for \\(\{r, s\}\\) in \\(T^k\\) and \\(i \not\in \{r, s\}\\).
+> _Corollary 3._ Assume vertex $i$ is out-of-kilter low and let $k$ be an element of $K(\pi, -u_i)$.
+> Then $\epsilon(\pi, -u_i) = \text{min} (\overline{c}\_{i j} - \overline{c}\_{r s})$ such that $\{i, j\}$ is a substitute for $\{r, s\}$ in $T^k$ and $i \not\in \{r, s\}$.
 
-> _Corollary 4._ Assume vertex \\(r\\) is out-of-kilter high.
-> Then \\(\epsilon(\pi, u_r) = \text{min} (\overline{c}\_{i j} - \overline{c}\_{r s})\\) such that \\(\{i, j\}\\) is a substitute for \\(\{r, s\}\\) in \\(T^k\\) and \\(r \not\in \{i, j\}\\).
+> _Corollary 4._ Assume vertex $r$ is out-of-kilter high.
+> Then $\epsilon(\pi, u_r) = \text{min} (\overline{c}\_{i j} - \overline{c}\_{r s})$ such that $\{i, j\}$ is a substitute for $\{r, s\}$ in $T^k$ and $r \not\in \{i, j\}$.
 
-These corollaries can be implemented with a modified version of the pseudocode listing above for finding \\(\epsilon\\) in the ascent method section.
+These corollaries can be implemented with a modified version of the pseudocode listing above for finding $\epsilon$ in the ascent method section.
 
 Once there are no more out-of-kilter vertices, the direction of ascent is not a unit vector and fractional weights are introduced.
 This is the cause of a major slow down in the convergence of the ascent method to the optimal solution, so it should be avoided if possible.
 
 Before we can discuss implementation details, there are still some more primaries to be reviewed.
-Let \\(X\\) and \\(Y\\) be disjoint sets of edges in the graph.
-Then let \\(\mathsf{T}(X, Y)\\) denote the set of 1-Trees which include all edges in \\(X\\) but none of the edges in \\(Y\\).
-Finally, define \\(w\_{X, Y}(\pi)\\) and \\(K\_{X, Y}(\pi)\\) as follows.
+Let $X$ and $Y$ be disjoint sets of edges in the graph.
+Then let $\mathsf{T}(X, Y)$ denote the set of 1-Trees which include all edges in $X$ but none of the edges in $Y$.
+Finally, define $w\_{X, Y}(\pi)$ and $K\_{X, Y}(\pi)$ as follows.
 
-\\[
+$$
 w\_{X, Y}(\pi) = \text{min}\_{k \in \mathsf{T}(X, Y)} (c\_k + \sum\_{i=1}^{i=n} \pi\_i v\_{i k}) \\\\\\
 K\_{X, Y}(\pi) = \{k\ |\ c\_k + \sum \pi\_i v\_{i k} = w\_{X, Y}(\pi)\}
-\\]
+$$
 
-From these functions, a revised definition of out-of-kilter high and low arise, allowing a vertex to be out-of-kilter relative to \\(X\\) and \\(Y\\).
+From these functions, a revised definition of out-of-kilter high and low arise, allowing a vertex to be out-of-kilter relative to $X$ and $Y$.
 
 During the completion of the branch and bound method, the branches are tracking in a list where each entry has the following format.
 
-\\[[X, Y, \pi, w\_{X, Y}(\pi)]\\]
+$$[X, Y, \pi, w\_{X, Y}(\pi)]$$
 
-Where \\(X\\) and \\(Y\\) are the disjoint sets discussed earlier, \\(\pi\\) is the vector we are using to perturb the edge weights and \\(w\_{X, Y}(\pi)\\) is the _bound_ of the entry.
+Where $X$ and $Y$ are the disjoint sets discussed earlier, $\pi$ is the vector we are using to perturb the edge weights and $w\_{X, Y}(\pi)$ is the _bound_ of the entry.
 
 At each iteration of the method, we consider the list entry with the minimum bound and try to find an out-of-kilter vertex.
 If we find one, we apply one iteration of the ascent method using the simplified unit vector as the direction of ascent.
 Here we can take advantage of integral weights if they exist.
 Perhaps the documentation for the Asadpour implementation in NetworkX should state that integral edge weights will perform better but that claim will have to be supported by our testing.
 
-If there is not an out-of-kilter vertex, we still need to find the direction of ascent in order to determine if we are at the maximum of \\(w(\pi)\\).
+If there is not an out-of-kilter vertex, we still need to find the direction of ascent in order to determine if we are at the maximum of $w(\pi)$.
 If the direction of ascent exists, we branch.
-If there is no direction of ascent, we search for a tour among \\(K\_{X, Y}(\pi)\\) and if none is found, we also branch.
+If there is no direction of ascent, we search for a tour among $K\_{X, Y}(\pi)$ and if none is found, we also branch.
 
 The branching process is as follows.
-From entry \\([X, Y, \pi, w\_{X, Y}(\pi)]\\) an edge \\(e \not\in X \cup Y\\) is chosen (Held and Karp do not give any criteria to branch on, so I believe the choose can be arbitrary) and the parent entry is replaced with two other entries of the forms
+From entry $[X, Y, \pi, w\_{X, Y}(\pi)]$ an edge $e \not\in X \cup Y$ is chosen (Held and Karp do not give any criteria to branch on, so I believe the choose can be arbitrary) and the parent entry is replaced with two other entries of the forms
 
-\\[
+$$
 [X \cup \{e\}, Y^\*, \pi, w\_{X \cup \{e\}, Y^\*}(\pi)] \quad \text{and} \quad [X^\*, Y \cup \{e\}, \pi, w\_{X^\*, Y \cup \{e\}}(\pi)]
-\\]
+$$
 
 An example of the branch and bound method is given on pages 1153 through 1156 in the Held and Karp paper.
 
 In order to implement this method, we need to be able to determine in addition to modifying some of the details of the ascent method.
 
-- If a vertex is either out-of-kilter in either direction with respect to \\(X\\) and \\(Y\\).
-- Search \\(K\_{X, Y}(\pi)\\) for a tour.
+- If a vertex is either out-of-kilter in either direction with respect to $X$ and $Y$.
+- Search $K\_{X, Y}(\pi)$ for a tour.
 
 The Held and Karp paper states that in order to find an out-of-kilter vertex, all we need to do is test the unit vectors.
-If for arbitrary member \\(k\\) of \\(K(\pi, u_i)\\), \\(v\_{i k} \geq 1\\) and the appropriate inverse holds for out-of-kilter low.
-From this process we can find out-of-kilter vertices by sequentially checking the \\(u_i\\)'s in an \\(O(n^2)\\) procedure.
+If for arbitrary member $k$ of $K(\pi, u_i)$, $v\_{i k} \geq 1$ and the appropriate inverse holds for out-of-kilter low.
+From this process we can find out-of-kilter vertices by sequentially checking the $u_i$'s in an $O(n^2)$ procedure.
 
-Searching \\(K\_{X, Y}(\pi)\\) for a tour would be easy if we can enumerate that set minimum 1-Trees.
-While I know how find one of the minimum 1-Trees, or a member of \\(K(\pi)\\), I am not sure how to find elements in \\(K(\pi, d)\\) or even all of the members of \\(K(\pi)\\).
-Using the properties in the Held and Karp paper, I do know how to refine \\(K(\pi)\\) into \\(K(\pi, d)\\) and \\(K(\pi)\\) into \\(K\_{X, Y}(\pi)\\).
+Searching $K\_{X, Y}(\pi)$ for a tour would be easy if we can enumerate that set minimum 1-Trees.
+While I know how find one of the minimum 1-Trees, or a member of $K(\pi)$, I am not sure how to find elements in $K(\pi, d)$ or even all of the members of $K(\pi)$.
+Using the properties in the Held and Karp paper, I do know how to refine $K(\pi)$ into $K(\pi, d)$ and $K(\pi)$ into $K\_{X, Y}(\pi)$.
 This will have to a blog post for another time.
 
 The most promising research paper I have been able to find on this problem is [this](https://www.scielo.br/j/pope/a/XHswBwRwJyrfL88dmMwYNWp/?lang=en&format=pdf) 2005 paper by Sörensen and Janssens titled _An Algorithm to Generate all Spanning Trees of a Graph in Order of Increasing Cost_.
-From here we generate spanning trees or arborescences until the cost moves upward at which point we have found all elements of \\(K(\pi)\\).
+From here we generate spanning trees or arborescences until the cost moves upward at which point we have found all elements of $K(\pi)$.
 
 ### Performance of the Branch and Bound Method
 
 Held and Karp did not program this method.
-We have some reason to believe that the performance of this method will be the best due to the fact that it is designed to be an improvement over the ascent method which was tested (somewhat) until \\(n = 25\\) which is still better than the column generation technique which was only consistently able to solve up to \\(n = 12\\).
+We have some reason to believe that the performance of this method will be the best due to the fact that it is designed to be an improvement over the ascent method which was tested (somewhat) until $n = 25$ which is still better than the column generation technique which was only consistently able to solve up to $n = 12$.
 
 ## References
 

--- a/content/posts/networkx/aTSP/completing-the-asadpour-algorithm/index.md
+++ b/content/posts/networkx/aTSP/completing-the-asadpour-algorithm/index.md
@@ -70,7 +70,7 @@ A few issues were present, as they always were going to be.
 
 First, my largest issue came from a part of a word being in parenthesis in the Asadpour paper on page 385.
 
-> This integral circulation \\(f^\*\\) corresponds to a directed (multi)graph \\(H\\) which contains \\(\vec{T}^\*\\).
+> This integral circulation $f^\*$ corresponds to a directed (multi)graph $H$ which contains $\vec{T}^\*$.
 
 Basically if the minimum flow is every larger than 1 along an edge, I need to add that many parallel edges in order to ensure that everything is still Eulerian.
 This became a problem quickly while developing my test cases as shown in the below example.
@@ -84,7 +84,7 @@ All of the others were just minor points where the pseudo code didn't directly t
 ## Understanding the Output
 
 The first thing I did once `asadpour_atsp` was take the fractional, symmetric Held Karp relaxation test graph and run it through the general `traveling_salesman_problem` function.
-Since there are random numbers involved here, the results were always within the \\(O(\log n / \log \log n)\\) approximation factor but were different.
+Since there are random numbers involved here, the results were always within the $O(\log n / \log \log n)$ approximation factor but were different.
 Three examples are shown below.
 
 <center><img src="example-tours.png" alt="Three possible ATSP tours on an example graph"/></center>
@@ -92,40 +92,40 @@ Three examples are shown below.
 The first thing we want to check is the approximation ratio.
 We know that the minimum cost output of the `traveling_saleman_problem` function is 304 (This is actually lower than the optimal tour in the undirected version, more on this later).
 Next we need to know what our maximum approximation factor is.
-Now, the Asadpour algorithm is \\(O(\log n / \log \log n)\\) which for our six vertex graph would be \\(\ln(6) / \ln(\ln(6)) \approx 3.0723\\).
-However, on page 386 they give the coefficients of the approximation as \\((2 + 8 \log n / \log \log n)\\) which would be \\(2 + 8 \times \ln(6) / \ln(\ln(6)) \approx 26.5784\\).
-(Remember that all \\(\log\\)'s in the Asadpour paper refer to the natural logarithm.)
+Now, the Asadpour algorithm is $O(\log n / \log \log n)$ which for our six vertex graph would be $\ln(6) / \ln(\ln(6)) \approx 3.0723$.
+However, on page 386 they give the coefficients of the approximation as $(2 + 8 \log n / \log \log n)$ which would be $2 + 8 \times \ln(6) / \ln(\ln(6)) \approx 26.5784$.
+(Remember that all $\log$'s in the Asadpour paper refer to the natural logarithm.)
 All of our examples are well below even the lower limit.
 
 For example 1:
 
-\\[
+$$
 \begin{array}{r l}
 \text{actual}: & 504 \\\\\\
 \text{expected}: & 304 \\\\\\
 \text{approx. factor}: & \frac{504}{304} \approx 1.6578 < 3.0723
 \end{array}
-\\]
+$$
 
 Example 2:
 
-\\[
+$$
 \begin{array}{r l}
 \text{actual}: & 404 \\\\\\
 \text{expected}: & 304 \\\\\\
 \text{approx. factor}: & \frac{404}{304} \approx 1.3289 < 3.0723
 \end{array}
-\\]
+$$
 
 Example 3:
 
-\\[
+$$
 \begin{array}{r l}
 \text{actual}: & 304 \\\\\\
 \text{expected}: & 304 \\\\\\
 \text{approx. factor}: & \frac{304}{304} = 1.0000 < 3.0723
 \end{array}
-\\]
+$$
 
 At this point, you've probably noticed that the examples given are strictly speaking, _not_ hamiltonian cycles: they visit vertices multiple times.
 This is because the graph we have is not complete.

--- a/content/posts/networkx/aTSP/entropy-distribution-setup/index.md
+++ b/content/posts/networkx/aTSP/entropy-distribution-setup/index.md
@@ -20,26 +20,26 @@ Referencing the Algorithm 1 from the Asadpour paper, we are now _finally_ on ste
 
 > ---
 >
-> **Algorithm 1** An \\(O(\log n / \log \log n)\\)-approximation algorithm for the ATSP
+> **Algorithm 1** An $O(\log n / \log \log n)$-approximation algorithm for the ATSP
 >
 > ---
 >
-> **Input:** A set \\(V\\) consisting of \\(n\\) points and a cost function \\(c\ :\ V \times V \rightarrow \mathbb{R}^+\\) satisfying the triangle inequality.
+> **Input:** A set $V$ consisting of $n$ points and a cost function $c\ :\ V \times V \rightarrow \mathbb{R}^+$ satisfying the triangle inequality.
 >
-> **Output:** \\(O(\log n / \log \log n)\\)-approximation of the asymmetric traveling salesman problem instance described by \\(V\\) and \\(c\\).
+> **Output:** $O(\log n / \log \log n)$-approximation of the asymmetric traveling salesman problem instance described by $V$ and $c$.
 >
-> 1. Solve the Held-Karp LP relaxation of the ATSP instance to get an optimum extreme point solution \\(x^\*\\).
->    Define \\(z^\*\\) as in (5), making it a symmetrized and scaled down version of \\(x^\*\\).
->    Vector \\(z^\*\\) can be viewed as a point in the spanning tree polytope of the undirected graph on the support of \\(x^\*\\) that one obtains after disregarding the directions of arcs (See Section 3.)
-> 2. Let \\(E\\) be the support graph of \\(z^\*\\) when the direction of the arcs are disregarded.
->    Find weights \\(\{\tilde{\gamma}\}\_{e \in E}\\) such that the exponential distribution on the spanning trees, \\(\tilde{p}(T) \propto \exp(\sum\_{e \in T} \tilde{\gamma}\_e)\\) (approximately) preserves the marginals imposed by \\(z^\*\\), i.e. for any edge \\(e \in E\\),
->    \\[\sum\_{T \in \mathcal{T} : T \ni e} \tilde{p}(T) \leq (1 + \epsilon) z^\*\_e\\]
->    for a small enough value of \\(\epsilon\\).
->    (In this paper we show that \\(\epsilon = 0.2\\) suffices for our purpose. See Section 7 and 8 for a description of how to compute such a distribution.)
-> 3. Sample \\(2\lceil \log n \rceil\\) spanning trees \\(T_1, \dots, T\_{2\lceil \log n \rceil}\\) from \\(\tilde{p}(.)\\).
->    For each of these trees, orient all its edges so as to minimize its cost with respect to our (asymmetric) cost function \\(c\\).
->    Let \\(T^\*\\) be the tree whose resulting cost is minimal among all of the sampled trees.
-> 4. Find a minimum cost integral circulation that contains the oriented tree \\(\vec{T}^\*\\).
+> 1. Solve the Held-Karp LP relaxation of the ATSP instance to get an optimum extreme point solution $x^\*$.
+>    Define $z^\*$ as in (5), making it a symmetrized and scaled down version of $x^\*$.
+>    Vector $z^\*$ can be viewed as a point in the spanning tree polytope of the undirected graph on the support of $x^\*$ that one obtains after disregarding the directions of arcs (See Section 3.)
+> 2. Let $E$ be the support graph of $z^\*$ when the direction of the arcs are disregarded.
+>    Find weights $\{\tilde{\gamma}\}\_{e \in E}$ such that the exponential distribution on the spanning trees, $\tilde{p}(T) \propto \exp(\sum\_{e \in T} \tilde{\gamma}\_e)$ (approximately) preserves the marginals imposed by $z^\*$, i.e. for any edge $e \in E$,
+>    $$\sum\_{T \in \mathcal{T} : T \ni e} \tilde{p}(T) \leq (1 + \epsilon) z^\*\_e$$
+>    for a small enough value of $\epsilon$.
+>    (In this paper we show that $\epsilon = 0.2$ suffices for our purpose. See Section 7 and 8 for a description of how to compute such a distribution.)
+> 3. Sample $2\lceil \log n \rceil$ spanning trees $T_1, \dots, T\_{2\lceil \log n \rceil}$ from $\tilde{p}(.)$.
+>    For each of these trees, orient all its edges so as to minimize its cost with respect to our (asymmetric) cost function $c$.
+>    Let $T^\*$ be the tree whose resulting cost is minimal among all of the sampled trees.
+> 4. Find a minimum cost integral circulation that contains the oriented tree $\vec{T}^\*$.
 >    Shortcut this circulation to a tour and output it. (See Section 4.)
 >
 > ---
@@ -49,29 +49,29 @@ Considering that there is no ellipsoid solver in the scientific python ecosystem
 
 The algorithm given in section 7 is as follows:
 
-> 1. Set \\(\gamma = \vec{0}\\).
-> 2. While there exists an edge \\(e\\) with \\(q_e(\gamma) > (1 + \epsilon) z_e\\):
->    - Compute \\(\delta\\) such that if we define \\(\gamma'\\) as \\(\gamma_e' = \gamma_e - \delta\\), and \\(\gamma_f' = \gamma_f\\) for all \\(f \in E\ \backslash \{e\}\\), then \\(q_e(\gamma') = (1 + \epsilon/2)z_e\\).
->    - Set \\(\gamma \leftarrow \gamma'\\).
-> 3. Output \\(\tilde{\gamma} := \gamma\\).
+> 1. Set $\gamma = \vec{0}$.
+> 2. While there exists an edge $e$ with $q_e(\gamma) > (1 + \epsilon) z_e$:
+>    - Compute $\delta$ such that if we define $\gamma'$ as $\gamma_e' = \gamma_e - \delta$, and $\gamma_f' = \gamma_f$ for all $f \in E\ \backslash \{e\}$, then $q_e(\gamma') = (1 + \epsilon/2)z_e$.
+>    - Set $\gamma \leftarrow \gamma'$.
+> 3. Output $\tilde{\gamma} := \gamma$.
 
-This structure is fairly straightforward, but we need to know what \\(q_e(\gamma)\\) is and how to calculate \\(\delta\\).
+This structure is fairly straightforward, but we need to know what $q_e(\gamma)$ is and how to calculate $\delta$.
 
-Finding \\(\delta\\) is very easy, the formula is given in the Asadpour paper
+Finding $\delta$ is very easy, the formula is given in the Asadpour paper
 (Although I did not realize this at the time that I wrote my GSoC proposal and re-derived the equation for delta. Fortunately my formula matches the one in the paper.)
 
-\\[
+$$
 \delta = \ln \frac{q\_e(\gamma)(1 - (1 + \epsilon / 2)z\_e)}{(1 - q\_e(\gamma))(1 + \epsilon / 2) z\_e}
-\\]
+$$
 
-Notice that the formula for \\(\delta\\) is reliant on \\(q_e(\gamma)\\).
-The paper defines \\(q_e(\gamma)\\) as
+Notice that the formula for $\delta$ is reliant on $q_e(\gamma)$.
+The paper defines $q_e(\gamma)$ as
 
-\\[
+$$
 q\_e(\gamma) = \frac{\sum\_{T \ni e} \exp(\gamma(T))}{\sum\_{T \in \mathcal{T}} \exp(\gamma(T))}
-\\]
+$$
 
-where \\(\gamma(T) = \sum\_{f \in T} \gamma_f\\).
+where $\gamma(T) = \sum\_{f \in T} \gamma_f$.
 
 The first thing that I noticed is that in the denominator the summation is over all spanning trees for in the graph, which for the complete graphs we will be working with is exponential so a `brute force' approach here is useless.
 Fortunately, Asadpour and team realized we can use Kirchhoff's matrix tree theorem to our advantage.
@@ -81,9 +81,9 @@ Basically, if you have a laplacian matrix (the adjacency matrix minus the degree
 This was something completely unexpected to me, and I think that it is very cool that this type of connection exists.
 
 The details of using Kirchhoff's theorem are given in section 5.3.
-We will be using a weighted laplacian \\(L\\) defined by
+We will be using a weighted laplacian $L$ defined by
 
-\\[
+$$
 L\_{i, j} = \left\\{
 \begin{array}{l l}
 -\lambda\_e & e = (i, j) \in E \\\\\\
@@ -91,73 +91,73 @@ L\_{i, j} = \left\\{
 0 & \text{otherwise}
 \end{array}
 \right.
-\\]
+$$
 
-where \\(\lambda_e = \exp(\gamma_e)\\).
+where $\lambda_e = \exp(\gamma_e)$.
 
-Now, we know that applying Krichhoff's theorem to \\(L\\) will return
+Now, we know that applying Krichhoff's theorem to $L$ will return
 
-\\[
+$$
 \sum\_{t \in \mathcal{T}} \prod\_{e \in T} \lambda\_e
-\\]
+$$
 
-but which part of \\(q_e(\gamma)\\) is that?
+but which part of $q_e(\gamma)$ is that?
 
-If we apply \\(\lambda_e = \exp(\gamma_e)\\), we find that
+If we apply $\lambda_e = \exp(\gamma_e)$, we find that
 
-\\[
+$$
 \begin{array}{r c l}
 \sum\_{T \in \mathcal{T}} \prod\_{e \in T} \lambda\_e &=& \sum\_{T \in \mathcal{T}} \prod\_{e \in T} \exp(\gamma\_e) \\\\\\
 && \sum\_{T \in \mathcal{T}} \exp\left(\sum\_{e \in T} \gamma\_e\right) \\\\\\
 && \sum\_{T \in \mathcal{T}} \exp(\gamma(T)) \\\\\\
 \end{array}
-\\]
+$$
 
 So moving from the first row to the second row is a confusing step, but essentially we are exploiting the properties of exponents.
-Recall that \\(\exp(x) = e^x\\), so could have written it as \\(\prod\_{e \in T} e^{\gamma_e}\\) but this introduces ambiguity as we would have multiple meanings of \\(e\\).
-Now, for all values of \\(e\\), \\(e_1, e_2, \dots, e\_{n-1}\\) in the spanning tree \\(T\\) that product can be expanded as
+Recall that $\exp(x) = e^x$, so could have written it as $\prod\_{e \in T} e^{\gamma_e}$ but this introduces ambiguity as we would have multiple meanings of $e$.
+Now, for all values of $e$, $e_1, e_2, \dots, e\_{n-1}$ in the spanning tree $T$ that product can be expanded as
 
-\\[
+$$
 \prod\_{e \in T} e^{\gamma\_e} = e^{\gamma\_{e\_1}} \times e^{\gamma\_{e\_2}} \times \dots \times e^{\gamma\_{e\_{n-1}}}
-\\]
+$$
 
 Each exponential factor has the same base, so we can collapse that into
 
-\\[
+$$
 e^{\gamma\_{e\_1} + \gamma\_{e\_2} + \dots + \gamma\_{e\_{n-1}}}
-\\]
+$$
 
 which is also
 
-\\[
+$$
 e^{\sum\_{e \in T} \gamma\_e}
-\\]
+$$
 
-but we know that \\(\sum\_{e \in T} \gamma_e\\) is \\(\gamma(T)\\), so it becomes
+but we know that $\sum\_{e \in T} \gamma_e$ is $\gamma(T)$, so it becomes
 
-\\[
+$$
 e^{\gamma(T)} = \exp(\gamma(T))
-\\]
+$$
 
-Once we put that back into the summation we arrive at the denominator in \\(q_e(\gamma)\\), \\(\sum\_{T \in \mathcal{T}} \exp(\gamma(T))\\).
+Once we put that back into the summation we arrive at the denominator in $q_e(\gamma)$, $\sum\_{T \in \mathcal{T}} \exp(\gamma(T))$.
 
-Next, we need to find the numerator for \\(q_e(\gamma)\\).
+Next, we need to find the numerator for $q_e(\gamma)$.
 Just as before, a `brute force' approach would be exponential in complexity, so we have to find a better way.
-Well, the only difference between the numerator and denominator is the condition on the outer summation, which the \\(T \in \mathcal{T}\\) being changed to \\(T \ni e\\) or every tree containing edge \\(e\\).
+Well, the only difference between the numerator and denominator is the condition on the outer summation, which the $T \in \mathcal{T}$ being changed to $T \ni e$ or every tree containing edge $e$.
 
 There is a way to use Krichhoff's matrix tree theorem here as well.
-If we had a graph in which every spanning tree could be mapped in a one-to-one fashion onto every spanning tree in the original graph which contains the desired edge \\(e\\).
-In order for a spanning tree to contain edge \\(e\\), we know that the endpoints of \\(e\\), \\((u, v)\\) will be directly connected to each other.
-So we are then interested in every spanning tree in which we reach vertex \\(u\\) and then leave from vertex \\(v\\).
-(As opposed to the spanning trees where we reach vertex \\(u\\) and then leave from that same vertex).
-In a sense, we are treating vertices \\(u\\) and \\(v\\) is the same vertex.
-We can apply this literally by _contracting_ \\(e\\) from the graph, creating \\(G / \{e\}\\).
-Every spanning tree in this graph can be uniquely mapped from \\(G / \{e\}\\) onto a spanning tree in \\(G\\) which contains the edge \\(e\\).
+If we had a graph in which every spanning tree could be mapped in a one-to-one fashion onto every spanning tree in the original graph which contains the desired edge $e$.
+In order for a spanning tree to contain edge $e$, we know that the endpoints of $e$, $(u, v)$ will be directly connected to each other.
+So we are then interested in every spanning tree in which we reach vertex $u$ and then leave from vertex $v$.
+(As opposed to the spanning trees where we reach vertex $u$ and then leave from that same vertex).
+In a sense, we are treating vertices $u$ and $v$ is the same vertex.
+We can apply this literally by _contracting_ $e$ from the graph, creating $G / \{e\}$.
+Every spanning tree in this graph can be uniquely mapped from $G / \{e\}$ onto a spanning tree in $G$ which contains the edge $e$.
 
-From here, the logic to show that a cofactor from \\(L\\) is actually the numerator of \\(q_e(\gamma)\\) parallels the logic for the denominator.
+From here, the logic to show that a cofactor from $L$ is actually the numerator of $q_e(\gamma)$ parallels the logic for the denominator.
 
 At this point, we have all of the needed information to create some pseudo code for the next function in the Asadpour method, `spanning_tree_distribution()`.
-Here I will use an inner function `q()` to find \\(q_e\\).
+Here I will use an inner function `q()` to find $q_e$.
 
 ```
 def spanning_tree_distribution
@@ -218,14 +218,14 @@ One thing that I am concerned about is my ability to test `spanning_tree_distrib
 There are no examples given in the Asadpour research paper and no other easy resources which I could turn to in order to find an oracle.
 
 The only method that I can think of right now would be to complete this function, then complete `sample_spanning_tree`.
-Once both functions are complete, I can sample a large number of spanning trees to find an experimental probability for each tree, then run a statistical test (such as an h-test) to see if the probability of each tree is near \\(\exp(\gamma(T))\\) which is the desired distribution.
+Once both functions are complete, I can sample a large number of spanning trees to find an experimental probability for each tree, then run a statistical test (such as an h-test) to see if the probability of each tree is near $\exp(\gamma(T))$ which is the desired distribution.
 An alternative test would be to use the marginals in the distribution and have to manually check that
 
-\\[
+$$
 \sum\_{T \in \mathcal{T} : T \ni e} p(T) \leq (1 + \epsilon) z^\*\_e,\ \forall\ e \in E
-\\]
+$$
 
-where \\(p(T)\\) is the experimental data from the sampled trees.
+where $p(T)$ is the experimental data from the sampled trees.
 
 Both methods seem very computationally intensive and because they are sampling from a probability distribution they may fail randomly due to an unlikely sample.
 

--- a/content/posts/networkx/aTSP/entropy-distribution/index.md
+++ b/content/posts/networkx/aTSP/entropy-distribution/index.md
@@ -18,46 +18,46 @@ resources:
 Implementing `spanning_tree_distribution` proved to have some NetworkX difficulties and one algorithmic difficulty.
 Recall that the algorithm for creating the distribution is given in the Asadpour paper as
 
-> 1. Set \\(\gamma = \vec{0}\\).
-> 2. While there exists an edge \\(e\\) with \\(q_e(\gamma) > (1 + \epsilon) z_e\\):
->    - Compute \\(\delta\\) such that if we define \\(\gamma'\\) as \\(\gamma_e' = \gamma_e - \delta\\), and \\(\gamma_f' = \gamma_f\\) for all \\(f \in E\ \backslash \{e\}\\), then \\(q_e(\gamma') = (1 + \epsilon/2)z_e\\).
->    - Set \\(\gamma \leftarrow \gamma'\\).
-> 3. Output \\(\tilde{\gamma} := \gamma\\).
+> 1. Set $\gamma = \vec{0}$.
+> 2. While there exists an edge $e$ with $q_e(\gamma) > (1 + \epsilon) z_e$:
+>    - Compute $\delta$ such that if we define $\gamma'$ as $\gamma_e' = \gamma_e - \delta$, and $\gamma_f' = \gamma_f$ for all $f \in E\ \backslash \{e\}$, then $q_e(\gamma') = (1 + \epsilon/2)z_e$.
+>    - Set $\gamma \leftarrow \gamma'$.
+> 3. Output $\tilde{\gamma} := \gamma$.
 
 Now, the procedure that I laid out in my last blog titled [Entropy Distribution Setup]({{< relref "entropy-distribution-setup" >}}) worked well for the while loop portion.
 All of my difficulties with the NetworkX API happened in the `q` inner function.
 
 After I programmed the function, I of course needed to run it and at first I was just printing the `gamma` dict out so that I could see what the values for each edge were.
-My first test uses the symmetric fractional Held Karp solution and to my surprise, every value of \\(\gamma\\) returned as 0.
+My first test uses the symmetric fractional Held Karp solution and to my surprise, every value of $\gamma$ returned as 0.
 I didn't think that this was intended behavior because if it was, there would be no reason to include this step in the overall Asadpour algorithm, so I started to dig around the code with PyCharm's debugger.
 The results were, as I suspected, not correct.
-I was running Krichhoff's tree matrix theorem on the original graph, so the returned probabilities were an order of magnitude smaller than the values of \\(z_e\\) that I was comparing them to.
+I was running Krichhoff's tree matrix theorem on the original graph, so the returned probabilities were an order of magnitude smaller than the values of $z_e$ that I was comparing them to.
 Additionally, all of the values were the same so I knew that this was a problem and not that the first edge I checked had unusually small probabilities.
 
 So, I returned to the Asadpour paper and started to ask myself questions like
 
 - Do I need to normalize the Held Karp answer in some way?
-- Do I need to consider edges outside of \\(E\\) (the undirected support of the Held Karp relaxation solution) or only work with the edges in \\(E\\)?
+- Do I need to consider edges outside of $E$ (the undirected support of the Held Karp relaxation solution) or only work with the edges in $E$?
 
 It was pretty easy to dismiss the first question, if normalization was required it would be mentioned in the Asadpour paper and without a description of how to normalize it the chances of me finding the `correct' way to do so would be next to impossible.
 The second question did take some digging.
-The sections of the Asadpour paper which talk about using Krichhoff's theorem all discuss it using the graph \\(G\\) which is why I was originally using all edges in \\(G\\) rather than the edges
-in \\(E\\).
-A few hints pointed to the fact that I needed to only consider the edges in \\(E\\), the first being the algorithm overview which states
+The sections of the Asadpour paper which talk about using Krichhoff's theorem all discuss it using the graph $G$ which is why I was originally using all edges in $G$ rather than the edges
+in $E$.
+A few hints pointed to the fact that I needed to only consider the edges in $E$, the first being the algorithm overview which states
 
-> Find weights \\(\{\tilde{\gamma}\}\_{e \in E}\\)
+> Find weights $\{\tilde{\gamma}\}\_{e \in E}$
 
-In particular the \\(e \in E\\) statement says that I do not need to consider the edges which are not in \\(E\\).
+In particular the $e \in E$ statement says that I do not need to consider the edges which are not in $E$.
 Secondly, Lemma 7.2 starts by stating
 
-> Let \\(G = (V, E)\\) be a graph with weights \\(\gamma_e\\) for \\(e \in E\\)
+> Let $G = (V, E)$ be a graph with weights $\gamma_e$ for $e \in E$
 
-Based on the current state of the function and these hints, I decided to reduce the input graph to `spanning_tree_distribution` to only edges with \\(z_e > 0\\).
-Running the test on the symmetric fractional solution now, it still returned \\(\gamma = \vec{0}\\) but the probabilities it was comparing were much closer during that first iteration.
+Based on the current state of the function and these hints, I decided to reduce the input graph to `spanning_tree_distribution` to only edges with $z_e > 0$.
+Running the test on the symmetric fractional solution now, it still returned $\gamma = \vec{0}$ but the probabilities it was comparing were much closer during that first iteration.
 Due to the fact that I do not have an example graph and distribution to work with, this could be the correct answer, but the fact that every value was the same still confused me.
 
-My next step was to determine the actual probability of an edge being in the spanning trees for the first iteration when \\(\gamma = \vec{0}\\).
-This can be easily done with my `SpanningTreeIterator` and exploits the fact that \\(\gamma = \vec{0} \equiv \lambda_e = 1\ \forall\ e \in \gamma\\) so we can just iterate over the spanning trees and count how often each edge appears.
+My next step was to determine the actual probability of an edge being in the spanning trees for the first iteration when $\gamma = \vec{0}$.
+This can be easily done with my `SpanningTreeIterator` and exploits the fact that $\gamma = \vec{0} \equiv \lambda_e = 1\ \forall\ e \in \gamma$ so we can just iterate over the spanning trees and count how often each edge appears.
 
 That script is listed below
 
@@ -94,7 +94,7 @@ for u, v in edge_frequency:
     )
 ```
 
-This output revealed that the probabilities returned by `q` should vary from edge to edge and that the correct solution for \\(\gamma\\) is certainly not \\(\vec{0}\\).
+This output revealed that the probabilities returned by `q` should vary from edge to edge and that the correct solution for $\gamma$ is certainly not $\vec{0}$.
 
 ```
 (networkx-dev) mjs@mjs-ubuntu:~/Workspace$ python3 spanning_tree_frequency.py
@@ -109,40 +109,40 @@ This output revealed that the probabilities returned by `q` should vary from edg
 (4, 3): 40 / 75 = 0.5333333333333333
 ```
 
-Let's focus on that first edge, \\((0, 1)\\).
-My brute force script says that it appears in 40 of the 75 spanning trees of the below graph where each edge is labelled with its \\(z_e\\) value.
+Let's focus on that first edge, $(0, 1)$.
+My brute force script says that it appears in 40 of the 75 spanning trees of the below graph where each edge is labelled with its $z_e$ value.
 
 <center><img src="test-graph-z-e.png" alt="probabilities over the example graph"/></center>
 
 Yet `q` was saying that the edge was in 24 of 75 spanning trees.
-Since the denominator was correct, I decided to focus on the numerator which is the number of spanning trees in \\(G\ \backslash\ \\{(0, 1)\\}\\).
+Since the denominator was correct, I decided to focus on the numerator which is the number of spanning trees in $G\ \backslash\ \\{(0, 1)\\}$.
 That graph would be the following.
 
 <center><img src="contracted-graph.png" alt="contracting on the least likely edge"/></center>
 
 An argument can be made that this graph should have a self-loop on vertex 0, but this does not affect the Laplacian matrix in any way so it is omitted here.
-Basically, the \\([0, 0]\\) entry of the adjacency matrix would be 1 and the degree of vertex 0 would be 5 and \\(5 - 1 = 4\\) which is what the entry would be without the self loop.
+Basically, the $[0, 0]$ entry of the adjacency matrix would be 1 and the degree of vertex 0 would be 5 and $5 - 1 = 4$ which is what the entry would be without the self loop.
 
-What was happening was that I was giving `nx.contracted_edge` a graph of the Graph class (not a directed graph since \\(E\\) is undirected) and was getting a graph of the Graph class back.
+What was happening was that I was giving `nx.contracted_edge` a graph of the Graph class (not a directed graph since $E$ is undirected) and was getting a graph of the Graph class back.
 The Graph class does not support multiple edges between two nodes so the returned graph only had one edge between node 0 and node 2 which was affecting the overall Laplacian matrix and thus the number of spanning trees.
 Switching from a Graph to a MultiGraph did the trick, but this subtle change should be mentioned in the NetworkX documentation for the function, linked [here](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.minors.contracted_edge.html?).
-I definitely believed that if a contracted an edge the output should automatically include both of the \\((0, 2)\\) edges.
+I definitely believed that if a contracted an edge the output should automatically include both of the $(0, 2)$ edges.
 An argument can be made for changing the default behavior to match this, but at the very least the documentation should explain this problem.
 
-Now the `q` function was returning the correct \\(40 / 75\\) answer for \\((0, 1)\\) and correct values for the rest of the edges so long as all of the \\(\gamma_e\\)'s were 0.
-But the test was erroring out with a `ValueError` when I tried to compute \\(\delta\\).
-`q` was returning a probability of an edge being in a sampled spanning tree of more than 1, which is clearly impossible but also caused the denominator of \\(\delta\\) to become negative and violate the domain of the natural log.
+Now the `q` function was returning the correct $40 / 75$ answer for $(0, 1)$ and correct values for the rest of the edges so long as all of the $\gamma_e$'s were 0.
+But the test was erroring out with a `ValueError` when I tried to compute $\delta$.
+`q` was returning a probability of an edge being in a sampled spanning tree of more than 1, which is clearly impossible but also caused the denominator of $\delta$ to become negative and violate the domain of the natural log.
 
-During my investigation of this problem, I noticed that after computing \\(\delta\\) and subtracting it from \\(\gamma_e\\), it did not have the desired effect on \\(q_e\\).
-Recall that we define \\(\delta\\) so that \\(\gamma_e - \delta\\) yields a \\(q_e\\) of \\((1 + \epsilon / 2) z_e\\).
-In other words, the effect of \\(\delta\\) is to decrease an edge probability which is too high, but in my current implementation it was having the opposite effect.
-The value of \\(q\_{(0, 1)}\\) was going from 0.5333 to just over 0.6.
-If I let this trend continue, the program would eventually hit one of those cases where \\(q_e \geq 1\\) and crash the program.
+During my investigation of this problem, I noticed that after computing $\delta$ and subtracting it from $\gamma_e$, it did not have the desired effect on $q_e$.
+Recall that we define $\delta$ so that $\gamma_e - \delta$ yields a $q_e$ of $(1 + \epsilon / 2) z_e$.
+In other words, the effect of $\delta$ is to decrease an edge probability which is too high, but in my current implementation it was having the opposite effect.
+The value of $q\_{(0, 1)}$ was going from 0.5333 to just over 0.6.
+If I let this trend continue, the program would eventually hit one of those cases where $q_e \geq 1$ and crash the program.
 
-Here I can use edge \\((0, 1)\\) as an example to show the problem.
-The original Laplacian matrix for \\(G\\) with \\(\gamma = \vec{0}\\) is
+Here I can use edge $(0, 1)$ as an example to show the problem.
+The original Laplacian matrix for $G$ with $\gamma = \vec{0}$ is
 
-\\[
+$$
 \begin{bmatrix}
 3 & -1 & -1 & 0 & 0 & -1 \\\\\\
 -1 & 3 & -1 & 0 & -1 & 0 \\\\\\
@@ -151,11 +151,11 @@ The original Laplacian matrix for \\(G\\) with \\(\gamma = \vec{0}\\) is
 0 & -1 & 0 & -1 & 3 & -1 \\\\\\
 -1 & 0 & 0 & -1 & -1 & 3
 \end{bmatrix}
-\\]
+$$
 
-and the Laplacian for \\(G\ \backslash\ \\{(0, 1)\\}\\) is
+and the Laplacian for $G\ \backslash\ \\{(0, 1)\\}$ is
 
-\\[
+$$
 \begin{bmatrix}
 4 & -2 & -1 & -1 & 0 \\\\\\
 -2 & 3 & 0 & 0 & -1 \\\\\\
@@ -163,13 +163,13 @@ and the Laplacian for \\(G\ \backslash\ \\{(0, 1)\\}\\) is
 -1 & 0 & -1 & 3 & -1 \\\\\\
 0 & -1 & -1 & -1 & 3
 \end{bmatrix}
-\\]
+$$
 
-The determinant of the first cofactor is how we get the \\(40 / 75\\).
-Now consider the Laplacian matrices after we updated \\(\gamma\_{(0, 1)}\\) for the first time.
-The one for \\(G\\) becomes
+The determinant of the first cofactor is how we get the $40 / 75$.
+Now consider the Laplacian matrices after we updated $\gamma\_{(0, 1)}$ for the first time.
+The one for $G$ becomes
 
-\\[
+$$
 \begin{bmatrix}
 2.74 & -0.74 & -1 & 0 & 0 & -1 \\\\\\
 -0.74 & 2.74 & -1 & 0 & -1 & 0 \\\\\\
@@ -178,24 +178,24 @@ The one for \\(G\\) becomes
 0 & -1 & 0 & -1 & 3 & -1 \\\\\\
 -1 & 0 & 0 & -1 & -1 & 3
 \end{bmatrix}
-\\]
+$$
 
 and its first cofactor determinant is reduced from 75 to 61.6.
-What do we expect the value of the matrix for \\(G\ \backslash\ \\{(0, 1)\\}\\) to be?
-Well, we know that the final value of \\(q_e\\) needs to be \\((1 + \epsilon / 2) z_e\\) or \\(1.1 \times 0.41\overline{6}\\) which is \\(0.458\overline{3}\\).
+What do we expect the value of the matrix for $G\ \backslash\ \\{(0, 1)\\}$ to be?
+Well, we know that the final value of $q_e$ needs to be $(1 + \epsilon / 2) z_e$ or $1.1 \times 0.41\overline{6}$ which is $0.458\overline{3}$.
 So
 
-\\[
+$$
 \begin{array}{r c l}
 \displaystyle\frac{x}{61.6} &=& 0.458\overline{3} \\\\\\
 x &=& 28.2\overline{3}
 \end{array}
-\\]
+$$
 
-and the value of the first cofactor determinant should be \\(28.2\overline{3}\\).
-However, the contracted Laplacian for \\((0, 1)\\) after the value of \\(\gamma_e\\) is updated is
+and the value of the first cofactor determinant should be $28.2\overline{3}$.
+However, the contracted Laplacian for $(0, 1)$ after the value of $\gamma_e$ is updated is
 
-\\[
+$$
 \begin{bmatrix}
 4 & -2 & -1 & -1 & 0 \\\\\\
 -2 & 3 & 0 & 0 & -1 \\\\\\
@@ -203,87 +203,87 @@ However, the contracted Laplacian for \\((0, 1)\\) after the value of \\(\gamma_
 -1 & 0 & -1 & 3 & -1 \\\\\\
 0 & -1 & -1 & -1 & 3
 \end{bmatrix}
-\\]
+$$
 
 the **same as before!**
-The only edge with a different \\(\gamma_e\\) than before is \\((0, 1)\\), but since it is the contracted edge it is no longer in the graph any more and thus cannot affect the value of the first cofactor's determinant!
+The only edge with a different $\gamma_e$ than before is $(0, 1)$, but since it is the contracted edge it is no longer in the graph any more and thus cannot affect the value of the first cofactor's determinant!
 
-But if we change the algorithm to add \\(\delta\\) to \\(\gamma_e\\) rather than subtract it, the determinant of the first cofactor for \\(G\ \backslash\ \\{e\\}\\)’s Laplacian will not change but the determinant for the Laplacian of \\(G\\)'s first cofactor will increase.
-This reduces the overall probability of picking \\(e\\) in a spanning tree.
-And, if we happen to use the same formula for \\(\delta\\) as before for our example of \\((0, 1)\\) then \\(q\_{(0, 1)}\\) becomes \\(0.449307\\).
-Recall our target value of \\(0.458\overline{3}\\).
-This answer has a \\(-1.96\%\\) error.
+But if we change the algorithm to add $\delta$ to $\gamma_e$ rather than subtract it, the determinant of the first cofactor for $G\ \backslash\ \\{e\\}$’s Laplacian will not change but the determinant for the Laplacian of $G$'s first cofactor will increase.
+This reduces the overall probability of picking $e$ in a spanning tree.
+And, if we happen to use the same formula for $\delta$ as before for our example of $(0, 1)$ then $q\_{(0, 1)}$ becomes $0.449307$.
+Recall our target value of $0.458\overline{3}$.
+This answer has a $-1.96\%$ error.
 
-\\[
+$$
 \begin{array}{r c l}
 \text{error} &=& \frac{0.449307 - 0.458333}{0.458333} \times 100 \\\\\\
 &=& \frac{-0.009026}{0.458333} \times 100 \\\\\\
 &=& -0.019693 \times 100 \\\\\\
 &=& -1.9693\%
 \end{array}
-\\]
+$$
 
 Also, the test now completes without error.
 
 ## Update! (28 July 2021)
 
 Further research and discussion with my mentors revealed just how flawed my original analysis was.
-In the next step, sampling the spanning trees, adding anything to \\(\gamma\\) would directly increase the probability that the edge would be sampled.
+In the next step, sampling the spanning trees, adding anything to $\gamma$ would directly increase the probability that the edge would be sampled.
 That being said, the original problem that I found was still an issue.
 
 Going back to the notion that we a graph on which every spanning tree maps to every spanning tree which contains the desired edge, this is still the key idea which lets us use Krichhoff's Tree Matrix Theorem.
-And, contracting the edge will still give a graph in which every spanning tree can be mapped to a corresponding spanning tree which includes \\(e\\).
-However, the weight of those spanning trees in \\(G \backslash \\{e\\}\\) do not quite map between the two graphs.
+And, contracting the edge will still give a graph in which every spanning tree can be mapped to a corresponding spanning tree which includes $e$.
+However, the weight of those spanning trees in $G \backslash \\{e\\}$ do not quite map between the two graphs.
 
-Recall that we are dealing with a multiplicative weight function, so the final weight of a tree is the product of all the \\(\lambda\\)'s on its edges.
+Recall that we are dealing with a multiplicative weight function, so the final weight of a tree is the product of all the $\lambda$'s on its edges.
 
-\\[
+$$
 c(T) = \prod\_{e \in E} \lambda\_e
-\\]
+$$
 
 The above statement can be expanded into
 
-\\[
+$$
 c(T) = \lambda\_1 \times \lambda\_2 \times \dots \times \lambda\_{|E|}
-\\]
+$$
 
-with some arbitrary ordering of the edges \\(1, 2, \dots |E|\\).
-Because the ordering of the edges is arbitrary and due to the associative property of multiplication, we can assume without loss of generality that the desired edge \\(e\\) is the last one in the sequence.
+with some arbitrary ordering of the edges $1, 2, \dots |E|$.
+Because the ordering of the edges is arbitrary and due to the associative property of multiplication, we can assume without loss of generality that the desired edge $e$ is the last one in the sequence.
 
-Any spanning tree in \\(G \backslash \\{e\\}\\) cannot include that last \\(\lambda\\) in it because that edge does not exist in the graph.
-Therefore in order to convert the weight from a tree in \\(G \backslash \\{e\\}\\) we need to multiply \\(\lambda_e\\) back into the weight of the contracted tree.
+Any spanning tree in $G \backslash \\{e\\}$ cannot include that last $\lambda$ in it because that edge does not exist in the graph.
+Therefore in order to convert the weight from a tree in $G \backslash \\{e\\}$ we need to multiply $\lambda_e$ back into the weight of the contracted tree.
 So, we can now state that
 
-\\[
+$$
 c(T \in \mathcal{T}: T \ni e) = \lambda\_e \prod\_{f \in E} \lambda\_f\ \forall\ T \in G \backslash \\{e\\}
-\\]
+$$
 
-or that for all trees in \\(G \backslash \\{e\\}\\), the cost of the corresponding tree in \\(G\\) is the product of its edge \\(\lambda\\)'s times the weight of the desired edge.
-Now recall that \\(q_e(\gamma)\\) is
+or that for all trees in $G \backslash \\{e\\}$, the cost of the corresponding tree in $G$ is the product of its edge $\lambda$'s times the weight of the desired edge.
+Now recall that $q_e(\gamma)$ is
 
-\\[
+$$
 \frac{\sum\_{T \ni e} \exp(\gamma(T))}{\sum\_{T \in \mathcal{T}} \exp(\gamma(T))}
-\\]
+$$
 
-In particular we are dealing with the numerator of the above fraction and using \\(\lambda_e = \exp(\gamma_e)\\) we can rewrite it as
+In particular we are dealing with the numerator of the above fraction and using $\lambda_e = \exp(\gamma_e)$ we can rewrite it as
 
-\\[
+$$
 \sum\_{T \ni e} \exp(\gamma(T)) = \sum\_{T \ni e} \prod\_{e \in T} \lambda\_e
-\\]
+$$
 
-Since we now know that we are missing the \\(\lambda_e\\) term, we can add it into the expression.
+Since we now know that we are missing the $\lambda_e$ term, we can add it into the expression.
 
-\\[
+$$
 \sum\_{T \ni e} \lambda\_e \times \prod\_{f \in T, f \not= e} \lambda\_f
-\\]
+$$
 
-Using the rules of summation, we can pull the \\(\lambda_e\\) factor out of the summation to get
+Using the rules of summation, we can pull the $\lambda_e$ factor out of the summation to get
 
-\\[
+$$
 \lambda\_e \times \sum\_{T \ni e} \prod\_{f \in T, f \not= e} \lambda\_f
-\\]
+$$
 
-And since we use that applying Krichhoff's Theorem to \\(G \backslash \\{e\\}\\) will yield everything except the factor of \\(\lambda_e\\), we can just multiply it back manually.
+And since we use that applying Krichhoff's Theorem to $G \backslash \\{e\\}$ will yield everything except the factor of $\lambda_e$, we can just multiply it back manually.
 This would let the peusdo code for `q` become
 
 ```
@@ -309,7 +309,7 @@ def q
 ```
 
 Making this small change to `q` worked very well.
-I was able to change back to subtracting \\(\delta\\) as the Asadpour paper does and even added a check to code so that every time we update a value in \\(\gamma\\) we know that \\(\delta\\) has had the correct effect.
+I was able to change back to subtracting $\delta$ as the Asadpour paper does and even added a check to code so that every time we update a value in $\gamma$ we know that $\delta$ has had the correct effect.
 
 ```python
 # Check that delta had the desired effect
@@ -329,7 +329,7 @@ I have written the test I have been working with into a proper test but since my
 So I must press onwards to write `sample_spanning_tree` and get a better test for both of those functions.
 
 As for the tests of `spanning_tree_distribution`, I would of course like to add more test cases.
-However, if the Held Karp relaxation returns a cycle as an answer, then there will be \\(n - 1\\) path spanning trees and the notion of creating this distribution in the first place as we have already found a solution to the ATSP.
+However, if the Held Karp relaxation returns a cycle as an answer, then there will be $n - 1$ path spanning trees and the notion of creating this distribution in the first place as we have already found a solution to the ATSP.
 I really need more truly fractional Held Karp solutions to expand the test of these next two functions.
 
 ## References

--- a/content/posts/networkx/aTSP/finalizing-held-karp/index.md
+++ b/content/posts/networkx/aTSP/finalizing-held-karp/index.md
@@ -89,7 +89,7 @@ for u, v, d in min_weight_tour.edges(data="weight"):
 
 ## Everything is Cool with the Ascent Method
 
-This is useful information as every though the ascent method returns a vector, because if the ascent method returns this solution (a.k.a \\(f(\pi) = 0\\)) we can calculate that vector off of the edges in the solution without having to explicitly enumerate the dict returned by `held_karp_ascent()`.
+This is useful information as every though the ascent method returns a vector, because if the ascent method returns this solution (a.k.a $f(\pi) = 0$) we can calculate that vector off of the edges in the solution without having to explicitly enumerate the dict returned by `held_karp_ascent()`.
 
 The first output from the program was a six vertex graph and is presented below.
 
@@ -116,10 +116,10 @@ sys     0m0.241s
 ```
 
 First I checked that the ascent method was returning a solution with the same weight, 144, which it was.
-Also, every entry in the vector was \\(0.866\overline{6}\\) which is \\(\frac{5}{6}\\) or the scaling factor from the Asadpour paper so I know that it was finding the exact solution.
-Because if this, my test in `test_traveling_salesman.py` checks that for all edges in the solution edge set both \\((u, v)\\) and \\((v, u)\\) are equal to \\(\frac{5}{6}\\).
+Also, every entry in the vector was $0.866\overline{6}$ which is $\frac{5}{6}$ or the scaling factor from the Asadpour paper so I know that it was finding the exact solution.
+Because if this, my test in `test_traveling_salesman.py` checks that for all edges in the solution edge set both $(u, v)$ and $(v, u)$ are equal to $\frac{5}{6}$.
 
-For my next test, I created a \\(7 \times 7\\) matrix to test with, and as expected the running time of the python script was much slower.
+For my next test, I created a $7 \times 7$ matrix to test with, and as expected the running time of the python script was much slower.
 
 ```
 ~ time python3 brute_force_optimal_tour.py
@@ -145,7 +145,7 @@ user	7m29.048s
 sys     0m0.245s
 ```
 
-Once again, the value of \\(f(\pi)\\) hit 0, so the ascent method returned an exact solution and my testing procedure was the same as for the six vertex graph.
+Once again, the value of $f(\pi)$ hit 0, so the ascent method returned an exact solution and my testing procedure was the same as for the six vertex graph.
 
 ## Trouble with Branch and Bound
 
@@ -157,8 +157,8 @@ I moved to the six vertex graph with high hopes, I already had a six vertex grap
 The six vertex graph created a large number of exceptions and errors when I ran the tests.
 I was able to determine why the errors were being generated, but the context did not conform which my expectations for the branch and bound method.
 
-Basically, `direction_of_ascent_kilter()` was finding a vertex which was out-of-kilter and returning the corresponding direction of ascent, but `find_epsilon()` was not finding any valid cross over edges and returning a maximum direction of travel of \\(\infty\\).
-While I could change the default value for the return value of `find_epsilon()` to zero, that would not solve the problem because the value of the vector \\(\pi\\) would get stuck and the program would enter an infinite loop.
+Basically, `direction_of_ascent_kilter()` was finding a vertex which was out-of-kilter and returning the corresponding direction of ascent, but `find_epsilon()` was not finding any valid cross over edges and returning a maximum direction of travel of $\infty$.
+While I could change the default value for the return value of `find_epsilon()` to zero, that would not solve the problem because the value of the vector $\pi$ would get stuck and the program would enter an infinite loop.
 
 I do have an analogy for this situation.
 Imagine that you are in an unfamiliar city and you have to meet somebody at the tallest building in that city.

--- a/content/posts/networkx/aTSP/finding-all-minimum-arborescences/index.md
+++ b/content/posts/networkx/aTSP/finding-all-minimum-arborescences/index.md
@@ -16,7 +16,7 @@ resources:
 ---
 
 There is only one thing that I need to figure out before the first coding period for GSoC starts on Monday: how to find _all_ of the minimum arborescences of a graph.
-This is the set \\(K(\pi)\\) in the Held and Karp paper from 1970 which can be refined down to \\(K(\pi, d)\\) or \\(K\_{X, Y}(\pi)\\) as needed.
+This is the set $K(\pi)$ in the Held and Karp paper from 1970 which can be refined down to $K(\pi, d)$ or $K\_{X, Y}(\pi)$ as needed.
 For more information as to why I need to do this, please see my last post [here]({{< relref "a-closer-look-at-held-karp" >}}).
 
 This is a place where my contributions to NetworkX to implement the Asadpour algorithm [1] for the directed traveling salesman problem will be useful to the rest of the NetworkX community (I hope).
@@ -41,15 +41,15 @@ The critical ideas for creating the partitions are given on pages 221 and 222 an
 
 In order to achieve these conditions, they define the generation of the partitions using this definition for a minimum spanning tree
 
-\\[
+$$
 s(P) = \{(i\_1, j\_1), \dots, (i\_r, j\_r), (t\_1, v\_1), \dots, (t\_{n-r-1}, v\_{n-r-1}\}
-\\]
+$$
 
-where the \\((i, j)\\) edges are the included edges of the original partition and the \\((t, v)\\) are from the open edges of the original partition.
-Now, to create the next set of partitions, take each of the \\((t, v)\\) edges sequentially and introduce them one at a time, make that edge an excluded edge in the first partition it appears in and an included edge in all subsequent partitions.
+where the $(i, j)$ edges are the included edges of the original partition and the $(t, v)$ are from the open edges of the original partition.
+Now, to create the next set of partitions, take each of the $(t, v)$ edges sequentially and introduce them one at a time, make that edge an excluded edge in the first partition it appears in and an included edge in all subsequent partitions.
 This will produce something to the effects of
 
-\\[
+$$
 \begin{array}{l}
 P\_1 = \{(i\_1, j\_1), \dots, (i\_r, j\_r), (\overline{m\_1, p\_1}), \dots, (\overline{m\_l, p\_l}), (\overline{t\_1, v\_1})\} \\\\\\
 P\_2 = \{(i\_1, j\_1), \dots, (i\_r, j\_r), (t\_1, v\_1), (\overline{m\_1, p\_1}), \dots, (\overline{m\_l, p\_l}), (\overline{t\_2, v\_2})\} \\\\\\
@@ -60,20 +60,20 @@ P\_{n-r-1} = \{(i\_1, j\_1), \dots, (i\_r, j\_r), (t\_1, v\_1), \dots, (t\_{n-r-
 (\overline{t\_{n-r-1}, v\_{n-r-1}})\}
 \end{multline\*} \\\\\\
 \end{array}
-\\]
+$$
 
 Now, if we extend this to a directed graph, our included and excluded edges become included and excluded arcs, but the definition of the spanning arborescence of a partition does not change.
-Let \\(s_a(P)\\) be the minimum spanning arborescence of a partition \\(P\\).
+Let $s_a(P)$ be the minimum spanning arborescence of a partition $P$.
 Then
 
-\\[
+$$
 s\_a(P) = \{(i\_1, j\_1), \dots, (i\_r, j\_r), (t\_1, v\_1), \dots, (t\_{n-r-1}, v\_{n-r-1}\}
-\\]
+$$
 
-\\(s_a(P)\\) is still constructed of all of the included arcs of the partition and a subset of the open arcs of that partition.
+$s_a(P)$ is still constructed of all of the included arcs of the partition and a subset of the open arcs of that partition.
 If we partition in the same manner as the Sörensen and Janssens paper [4], then their cannot be spanning trees which both include and exclude a given edge and this conflict exists for every combination of partitions.
 
-Clearly the original arborescence, which includes all of the \\((t_1, v_1), \dots, (t\_{n-r-1}, v\_{n-r-1})\\) cannot be an element of any of the resulting partitions.
+Clearly the original arborescence, which includes all of the $(t_1, v_1), \dots, (t\_{n-r-1}, v\_{n-r-1})$ cannot be an element of any of the resulting partitions.
 
 Finally, there is the claim that the union of the resulting partitions is the original partition minus the original minimum spanning tree.
 Being honest here, this claim took a while for me to understand.
@@ -88,21 +88,21 @@ We need to modify Edmonds’ algorithm to mandate that certain arcs be included 
 To start, a review of this algorithm is in order.
 The original description of the algorithm is given on pages 234 and 235 of Jack Edmonds' 1967 paper _Optimum Branchings_ [2] and roughly speaking it has three major steps.
 
-1. For each vertex \\(v\\), find the incoming arc with the smallest weight and place that arc in a bucket \\(E^i\\) and the vertex in a bucket \\(D^i\\).
-   Repeat this step until either (a) \\(E^i\\) no longer qualifies as a branching or (b) all vertices of the graph are in \\(D^i\\).
+1. For each vertex $v$, find the incoming arc with the smallest weight and place that arc in a bucket $E^i$ and the vertex in a bucket $D^i$.
+   Repeat this step until either (a) $E^i$ no longer qualifies as a branching or (b) all vertices of the graph are in $D^i$.
    If (a) occurs, go to step 2, otherwise go to step 3.
-2. If \\(E^i\\) no longer qualifies as a branching then it must contain a cycle.
-   Contract all of the vertices of the cycle into one new one, say \\(v_1^{i + 1}\\).
-   Every edge which has one endpoint in the cycle has that endpoint replaced with \\(v_1^{i + 1}\\) and its cost updated.
-   Using this new graph \\(G^{i + 1}\\), create buckets \\(D^{i + 1}\\) containing the nodes in both \\(G^{i + 1}\\) and \\(D^i\\) and \\(E^{i + 1}\\) containing edges in both \\(G^{i + 1}\\) and \\(E^i\\)
-   (i.e. remove the edges and vertices which are affected by the creation of \\(G^{i + 1}\\).)
-   Return to step 1 and apply it to graph \\(G^{i + 1}\\).
+2. If $E^i$ no longer qualifies as a branching then it must contain a cycle.
+   Contract all of the vertices of the cycle into one new one, say $v_1^{i + 1}$.
+   Every edge which has one endpoint in the cycle has that endpoint replaced with $v_1^{i + 1}$ and its cost updated.
+   Using this new graph $G^{i + 1}$, create buckets $D^{i + 1}$ containing the nodes in both $G^{i + 1}$ and $D^i$ and $E^{i + 1}$ containing edges in both $G^{i + 1}$ and $E^i$
+   (i.e. remove the edges and vertices which are affected by the creation of $G^{i + 1}$.)
+   Return to step 1 and apply it to graph $G^{i + 1}$.
 3. Once this step is reached, we have a smaller graph for which we have found a minimum spanning arborescence.
    Now we need to un-contract all of the cycles to return to the original graph.
-   To do this, if the node \\(v_1^{i + 1}\\) is the root of the arborescence or not.
-   - \\(v_1^{i + 1}\\) is the root: Remove the arc of maximum weight from the cycle represented by \\(v_1^{i + 1}\\).
-   - \\(v_1^{i + 1}\\) is not the root: There is a single arc directed towards \\(v_1^{i + 1}\\) which translates into an arc directed to one of the vertices in the cycle represented by \\(v_1^{i + 1}\\).
-     Because \\(v_1^{i + 1}\\) represents a cycle, there is another arc wholly internal to the cycle which is directed into the same vertex as the incoming edge to the cycle.
+   To do this, if the node $v_1^{i + 1}$ is the root of the arborescence or not.
+   - $v_1^{i + 1}$ is the root: Remove the arc of maximum weight from the cycle represented by $v_1^{i + 1}$.
+   - $v_1^{i + 1}$ is not the root: There is a single arc directed towards $v_1^{i + 1}$ which translates into an arc directed to one of the vertices in the cycle represented by $v_1^{i + 1}$.
+     Because $v_1^{i + 1}$ represents a cycle, there is another arc wholly internal to the cycle which is directed into the same vertex as the incoming edge to the cycle.
      Delete the internal one to break the cycle.
      Repeat until the original graph has been restored.
 

--- a/content/posts/networkx/aTSP/held-karp-relaxation/index.md
+++ b/content/posts/networkx/aTSP/held-karp-relaxation/index.md
@@ -19,41 +19,41 @@ In linear programming, we sometimes need to take what would be a integer program
 One particular application of this process is Held-Karp relaxation used the first part of the Asadpour algorithm for the Asymmetric Traveling Salesman Problem, where we find the lower bound of the approximation.
 Normally the relaxation is written as follows.
 
-\\[
+$$
 \begin{array}{c l l}
 \text{min} & \sum_{a} c(a)x_a \\\\\\
 \text{s.t.} & x(\delta^+(U)) \geqslant 1 & \forall\ U \subset V \text{ and } U \not= \emptyset \\\\\\
 & x(\delta^+(v)) = x(\delta^-(v)) = 1 & \forall\ v \in V \\\\\\
 & x_a \geqslant 0 & \forall\ a
 \end{array}
-\\]
+$$
 
 This is a convenient way to write the program, but if we want to solve it, and we definitely do, we need it written in standard form for a linear program.
 Standard form is represented using a matrix for the set of constraints and vectors for the objective function.
 It is shown below
 
-\\[
+$$
 \begin{array}{c l}
 \text{min} & Z = c^TX \\\\\\
 \text{s.t.} & AX = b \\\\\\
 & X \geqslant 0
 \end{array}
-\\]
+$$
 
-Where \\(c\\) is the coefficient vector for objective function, \\(X\\) is the vector for the values of all of the variables, \\(A\\) is the coefficient matrix for the constraints and \\(b\\) is a vector of what the constraints are equal to.
+Where $c$ is the coefficient vector for objective function, $X$ is the vector for the values of all of the variables, $A$ is the coefficient matrix for the constraints and $b$ is a vector of what the constraints are equal to.
 Once a linear program is in this form there are efficient algorithms which can solve it.
 
 In the Held-Karp relaxation, the objective function is a summation, so we can expand it to a summation.
-If there are \\(n\\) edges then it becomes
+If there are $n$ edges then it becomes
 
-\\[
+$$
 \sum_{a} c(a)x_a = c(1)x_1 + c(2)x_2 + c(3)x_3 + \dots + c(n)_n
-\\]
+$$
 
-Where \\(c(a)\\) is the weight of that edge in the graph.
+Where $c(a)$ is the weight of that edge in the graph.
 From here it is easy to convert the objective function into two vectors which satisfies the standard form.
 
-\\[
+$$
 \begin{array}{rCl}
 c &=& \begin{bmatrix}
 c_1 & c_2 & c_3 & \dots & c_n
@@ -62,51 +62,51 @@ X &=& \begin{bmatrix}
 x_1 & x_2 & x_3 & \dots & x_n
 \end{bmatrix}^T
 \end{array}
-\\]
+$$
 
 Now we have to convert the constraints to be in standard form.
-First and foremost, notice that the Held-Karp relaxation contains \\(x_a \geqslant 0\ \forall\ a\\) and the standard form uses \\(X \geqslant 0\\), so these constants match already and no work is needed.
+First and foremost, notice that the Held-Karp relaxation contains $x_a \geqslant 0\ \forall\ a$ and the standard form uses $X \geqslant 0$, so these constants match already and no work is needed.
 As for the others... well they do need some work.
 
-Starting with the first constraint in the Held-Karp relaxation, \\(x(\delta^+(U)) \geqslant 1\ \forall\ U \subset V\\) and \\(U \not= \emptyset\\).
-This constraint specifies that for every subset of the vertex set \\(V\\), that subset must have at lest one arc with its tail in \\(U\\) and its head not in \\(U\\).
-For any given \\(\delta^+(U)\\), which is defined in the paper is \\(\delta^+(U) = \{a = (u, v) \in A: u \in U, v \not\in U\}\\) where \\(A\\) in this set is the set of all arcs in the graph, the coefficients on arcs not in \\(U\\) are zero.
-Arcs in \\(\delta^+(U)\\) have a coefficient of \\(1\\) as their full weight is counted as part of \\(\delta^+(U)\\).
-We know that there are about \\(2^{|V|}\\) subsets of the vertex \\(V\\), so this constraint adds that many rows to the constraint matrix \\(A\\).
+Starting with the first constraint in the Held-Karp relaxation, $x(\delta^+(U)) \geqslant 1\ \forall\ U \subset V$ and $U \not= \emptyset$.
+This constraint specifies that for every subset of the vertex set $V$, that subset must have at lest one arc with its tail in $U$ and its head not in $U$.
+For any given $\delta^+(U)$, which is defined in the paper is $\delta^+(U) = \{a = (u, v) \in A: u \in U, v \not\in U\}$ where $A$ in this set is the set of all arcs in the graph, the coefficients on arcs not in $U$ are zero.
+Arcs in $\delta^+(U)$ have a coefficient of $1$ as their full weight is counted as part of $\delta^+(U)$.
+We know that there are about $2^{|V|}$ subsets of the vertex $V$, so this constraint adds that many rows to the constraint matrix $A$.
 
-Moving to the next constraint, \\(x(\delta^+(v)) = x(\delta^-(v)) = 1\\), we first need to split it in two.
+Moving to the next constraint, $x(\delta^+(v)) = x(\delta^-(v)) = 1$, we first need to split it in two.
 
-\\[
+$$
 \begin{array}{rCl}
 x(\delta^+(v)) &=& 1 \\\\\\
 x(\delta^-(v)) &=& 1
 \end{array}
-\\]
+$$
 
 Similar to the last constraint, each of these say that the number of arcs entering and leaving a vertex in the graph need to equal one.
-For each vertex \\(v\\) we find all the arcs which start at \\(v\\) and those are the members of \\(\delta^+(v)\\), so they have a weight of 1 and all others have a weight of zero.
-The opposite is true for \\(\delta^-(v)\\), every vertex which has a head on \\(v\\) has a weight or coefficient of 1 while the rest have a weight of zero.
-This adds \\(2 \times |V|\\) rows to \\(A\\), the coefficient matrix which brings the total to \\(2^{|V|} + 2|V|\\) rows.
+For each vertex $v$ we find all the arcs which start at $v$ and those are the members of $\delta^+(v)$, so they have a weight of 1 and all others have a weight of zero.
+The opposite is true for $\delta^-(v)$, every vertex which has a head on $v$ has a weight or coefficient of 1 while the rest have a weight of zero.
+This adds $2 \times |V|$ rows to $A$, the coefficient matrix which brings the total to $2^{|V|} + 2|V|$ rows.
 
-## The Impossible Size of \\(A\\)
+## The Impossible Size of $A$
 
-We already know that \\(A\\) will have \\(2^{|V|} + 2|V|\\) rows.
-But how many columns will \\(A\\) have?
-We know that each arc is a variable so at lest \\(|E|\\) rows, but in a traditional matrix form of a linear program, we have to introduce slack and surplus variables so that \\(AX = b\\) and not \\(AX \geqslant b\\) or any other inequality operation.
-The \\(2|V|\\) rows already comply with this requirement, but the rows created with every subset of \\(V\\) do _not_, those rows only require that \\(x(\delta^+(U)) \geqslant 1\\), so we introduce a surplus variable for each of these rows bring the column count to \\(|E| + 2^{|V|}\\).
+We already know that $A$ will have $2^{|V|} + 2|V|$ rows.
+But how many columns will $A$ have?
+We know that each arc is a variable so at lest $|E|$ rows, but in a traditional matrix form of a linear program, we have to introduce slack and surplus variables so that $AX = b$ and not $AX \geqslant b$ or any other inequality operation.
+The $2|V|$ rows already comply with this requirement, but the rows created with every subset of $V$ do _not_, those rows only require that $x(\delta^+(U)) \geqslant 1$, so we introduce a surplus variable for each of these rows bring the column count to $|E| + 2^{|V|}$.
 
 Now, the Held-Karp relaxation performed in the Asadpour algorithm in is done on the complete bi-directed graph.
-For a graph with \\(n\\) vertices, there will be \\(2 \times \binom{n}{2}\\) arcs in the graph.
-The updated value for the size of \\(A\\) is then that it is a
+For a graph with $n$ vertices, there will be $2 \times \binom{n}{2}$ arcs in the graph.
+The updated value for the size of $A$ is then that it is a
 
-\\[
+$$
 \left(2^n + 2n \right)\times \left(2\binom{n}{2} + 2^n\right)
-\\]
+$$
 
 matrix.
 This is _very_ large.
-For \\(n = 100\\) there are \\(1.606 \times 10^{60}\\) elements in the matrix.
-Allocating a measly 8 bits per entry sill consumes over \\(1.28 \times 10^{52}\\) gigabytes of memory.
+For $n = 100$ there are $1.606 \times 10^{60}$ elements in the matrix.
+Allocating a measly 8 bits per entry sill consumes over $1.28 \times 10^{52}$ gigabytes of memory.
 
 This is an impossible amount of memory for any computer that we could run NetworkX on.
 

--- a/content/posts/networkx/aTSP/held-karp-separation-oracle/index.md
+++ b/content/posts/networkx/aTSP/held-karp-separation-oracle/index.md
@@ -33,47 +33,47 @@ The hyperplane that the oracle returns is then used to construct the next ellips
 This is, however, a topic for another post.
 Right now I want to focus on this 'black-box' separation oracle.
 
-The reason that the Held-Karp relaxation is semi-infinite is because for a graph with \\(n\\) vertices, there are \\(2^n + 2n\\) constraints in the program.
-A naive approach to the separation oracle would be to check each constraint individually for the input vector, creating a program with \\(O(2^n)\\) running time.
+The reason that the Held-Karp relaxation is semi-infinite is because for a graph with $n$ vertices, there are $2^n + 2n$ constraints in the program.
+A naive approach to the separation oracle would be to check each constraint individually for the input vector, creating a program with $O(2^n)$ running time.
 While it would terminate eventually, it certainly would take a _long_ time to do so.
 
 So, we look for a more efficient way to do this.
 Recall from the Asadpour paper [1] that the Held-Karp relaxation is the following linear program.
 
-\\[
+$$
 \begin{array}{c l l}
 \text{min} & \sum_{a} c(a)x_a \\\\\\
 \text{s.t.} & x(\delta^+(U)) \geqslant 1 & \forall\ U \subset V \text{ and } U \not= \emptyset \\\\\\
 & x(\delta^+(v)) = x(\delta^-(v)) = 1 & \forall\ v \in V \\\\\\
 & x_a \geqslant 0 & \forall\ a
 \end{array}
-\\]
+$$
 
 The first set of constraints ensures that the output of the relaxation is connected.
 This is called _subtour elimination_, and it prevents a solution with multiple disconnected clusters by ensuring that every set of vertices has at least one total outgoing arc (we are currently dealing with fractional arcs).
-From the perspective of the separation oracle, we do not care about all of the sets of vertices for which \\(x(\delta^+(U)) \geqslant 1\\), only trying to find one such subset of the vertices where \\(x(\delta^+(U)) < 1\\).
+From the perspective of the separation oracle, we do not care about all of the sets of vertices for which $x(\delta^+(U)) \geqslant 1$, only trying to find one such subset of the vertices where $x(\delta^+(U)) < 1$.
 
-In order to find such a set of vertices \\(U \in V\\) where \\(x(\delta^+(U)) < 1\\) we can find the subset \\(U\\) with the smallest value of \\(\delta^+(x)\\) for all \\(U \subset V\\).
+In order to find such a set of vertices $U \in V$ where $x(\delta^+(U)) < 1$ we can find the subset $U$ with the smallest value of $\delta^+(x)$ for all $U \subset V$.
 That is, find the _global minimum cut_ in the complete digraph using the edge capacities given by the input vector to the separation oracle.
-Using lecture notes by Michel X. Goemans (who is also one of the authors of the Asadpour algorithm this project seeks to implement), [2] we can find such a minimum cut with \\(2(n - 1)\\) maximum flow calculations.
+Using lecture notes by Michel X. Goemans (who is also one of the authors of the Asadpour algorithm this project seeks to implement), [2] we can find such a minimum cut with $2(n - 1)$ maximum flow calculations.
 
 The algorithm described in section 6.4 of the lecture notes [2] is fairly simple.
-Let \\(S\\) be a subset of \\(V\\) and \\(T\\) be a subset of \\(V\\) such that the \\(s-t\\) cut is the global minimum cut for the graph.
-First, we pick an arbitrary \\(s\\) in the graph.
-By definition, \\(s\\) is either in \\(S\\) or it is in \\(T\\).
-We now iterate through every other vertex in the graph \\(t\\), and compute the \\(s-t\\) and \\(t-s\\) minimum cut.
-If \\(s \in S\\) than we will find that one of the choices of \\(t\\) will produce the global minimum cut and the case where \\(s \not\in S\\) or \\(s \in T\\) is covered by using the \\(t-s\\) cuts.
+Let $S$ be a subset of $V$ and $T$ be a subset of $V$ such that the $s-t$ cut is the global minimum cut for the graph.
+First, we pick an arbitrary $s$ in the graph.
+By definition, $s$ is either in $S$ or it is in $T$.
+We now iterate through every other vertex in the graph $t$, and compute the $s-t$ and $t-s$ minimum cut.
+If $s \in S$ than we will find that one of the choices of $t$ will produce the global minimum cut and the case where $s \not\in S$ or $s \in T$ is covered by using the $t-s$ cuts.
 
-According to Geoman [2], the complexity of finding the global min cut in a weighted digraph, using an effeicent maxflow algorithm, is \\(O(mn^2\log(n^2/m))\\).
+According to Geoman [2], the complexity of finding the global min cut in a weighted digraph, using an effeicent maxflow algorithm, is $O(mn^2\log(n^2/m))$.
 
-The second constraint can be checked in \\(O(n)\\) time with a simple loop.
+The second constraint can be checked in $O(n)$ time with a simple loop.
 It makes sense to actually check this one first as it is computationally simpler and thus if one of these conditions are violated we will be able to return the violated hyperplane faster.
 
-Now we have reduced the complexity of the oracle from \\(O(2^n)\\) to the same as finding the global min cut, \\(O(mn^2\log(n^2/m))\\) which is substantially better.
+Now we have reduced the complexity of the oracle from $O(2^n)$ to the same as finding the global min cut, $O(mn^2\log(n^2/m))$ which is substantially better.
 For example, let us consider an initial graph with 100 vertices.
-Using the \\(O(2^n)\\) method, that is \\(1.2677 \times 10^{30}\\) subsets \\(U\\) that we need to check _times_ whatever the complexity of actually determining whether the constraint violates \\(x(\delta^+(U)) \geqslant 1\\).
-For that same complete digraph on 100 vertices, we know that there \\(n = 100\\) and \\(m = \binom{100}{2} = 4950\\).
-Using the global min cut approach, the complexity which includes finding the max flow as well as the number of times it needs to be found, is \\(15117042\\) or \\(1.5117 \times 10^7\\) which is faster by a factor of \\(10^{23}\\).
+Using the $O(2^n)$ method, that is $1.2677 \times 10^{30}$ subsets $U$ that we need to check _times_ whatever the complexity of actually determining whether the constraint violates $x(\delta^+(U)) \geqslant 1$.
+For that same complete digraph on 100 vertices, we know that there $n = 100$ and $m = \binom{100}{2} = 4950$.
+Using the global min cut approach, the complexity which includes finding the max flow as well as the number of times it needs to be found, is $15117042$ or $1.5117 \times 10^7$ which is faster by a factor of $10^{23}$.
 
 ## References
 

--- a/content/posts/networkx/aTSP/implementing-the-held-karp-relaxation/index.md
+++ b/content/posts/networkx/aTSP/implementing-the-held-karp-relaxation/index.md
@@ -80,20 +80,20 @@ and I now had two algorithms returning this solution:
 As I mentioned before, the branch and bound method is more human-computable than the ascent method, so I decided to follow the execution of my implementation with the one given in [1].
 Below, the left side is the data from the Held and Karp paper and on the right my program's execution on the directed version.
 
-| Undirected Graph                                                                                               | Directed Graph                                                                                                 |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| Iteration 1:                                                                                                   |
+| Undirected Graph                                                                                           | Directed Graph                                                                                             |
+| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Iteration 1:                                                                                               |
 | Starting configuration: $(\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & 0 & 0 & 0 \end{bmatrix}, 196)$ | Starting configuration: $(\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & 0 & 0 & 0 \end{bmatrix}, 196)$ |
-| Minimum 1-Trees:                                                                                               | Minimum 1-Arborescences:                                                                                       |
-| ![minimum 1 trees](minimum-1-trees-iteration-1.png)                                                            | ![minimum 1 arborescences](minimum-1-arborescences-iteration-1.png)                                            |
-| Vertex 3 out-of-kilter LOW                                                                                     | Vertex 3 out-of-kilter LOW                                                                                     |
+| Minimum 1-Trees:                                                                                           | Minimum 1-Arborescences:                                                                                   |
+| ![minimum 1 trees](minimum-1-trees-iteration-1.png)                                                        | ![minimum 1 arborescences](minimum-1-arborescences-iteration-1.png)                                        |
+| Vertex 3 out-of-kilter LOW                                                                                 | Vertex 3 out-of-kilter LOW                                                                                 |
 | $d = \begin{bmatrix} 0 & 0 & 0 & -1 & 0 & 0 \end{bmatrix}$                                                 | $d = \begin{bmatrix} 0 & 0 & 0 & -1 & 0 & 0 \end{bmatrix}$                                                 |
 | $\epsilon(\pi, d) = 5$                                                                                     | $\epsilon(\pi, d) = 5$                                                                                     |
 | New configuration: $(\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & -5 & 0 & 0 \end{bmatrix}, 201)$     | New configuration: $(\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & -5 & 0 & 0 \end{bmatrix}, 212)$     |
-|                                                                                                                |
-| Iteration 2:                                                                                                   |
-| Minimum 1-Trees:                                                                                               | Minimum 1-Arborescences:                                                                                       |
-| ![minimum 1 trees](minimum-1-trees-iteration-2.png)                                                            | ![minimum 1 arborescences](minimum-1-arborescences-iteration-2.png)                                            |
+|                                                                                                            |
+| Iteration 2:                                                                                               |
+| Minimum 1-Trees:                                                                                           | Minimum 1-Arborescences:                                                                                   |
+| ![minimum 1 trees](minimum-1-trees-iteration-2.png)                                                        | ![minimum 1 arborescences](minimum-1-arborescences-iteration-2.png)                                        |
 
 In order to get these results, I forbid the program from being able to choose to connect vertex 0 to the same other vertex for both the incoming and outgoing edge.
 However, it is very clear that from the start, iteration two was not going to be the same.

--- a/content/posts/networkx/aTSP/implementing-the-held-karp-relaxation/index.md
+++ b/content/posts/networkx/aTSP/implementing-the-held-karp-relaxation/index.md
@@ -24,28 +24,28 @@ Fortunately, this was indeed the case and I was able to correctly implement the 
 
 ## Initial Implementation of the Branch and Bound Method
 
-The branch and bound method follows from the ascent method, but tweaks how we determine the direction of ascent and simplifies the expression used for \\(\epsilon\\).
+The branch and bound method follows from the ascent method, but tweaks how we determine the direction of ascent and simplifies the expression used for $\epsilon$.
 As a reminder, we use the notion of an _out-of-kilter_ vertex to find directions of ascent which are unit vectors or negative unit vectors.
 An out-of-kilter vertex is a vertex which is consistently not connected enough or connected too much in the set of minimum 1-arborescences of a graph.
 The formal definition is given on page 1151 as
 
-> Vertex \\(i\\) is said to be _out-of-kilter high_ at the point \\(\pi\\), if, for all \\(k \in K(\pi), v\_{ik} \geqq 1\\);
-> similarly, vertex \\(i\\) is _out-of-kilter low_ at the point \\(\pi\\) if, for all \\(k \in K(\pi), v\_{ik} = -1\\).
+> Vertex $i$ is said to be _out-of-kilter high_ at the point $\pi$, if, for all $k \in K(\pi), v\_{ik} \geqq 1$;
+> similarly, vertex $i$ is _out-of-kilter low_ at the point $\pi$ if, for all $k \in K(\pi), v\_{ik} = -1$.
 
-Where \\(v\_{ik}\\) is the degree of the vertex minus two.
+Where $v\_{ik}$ is the degree of the vertex minus two.
 First, I created a function called `direction_of_ascent_kilter()` which returns a direction of ascent based on whether a vertex is out-of-kilter.
-However, I did not use the method mentioned on the paper by Held and Karp, which is to find a member of \\(K(\pi, u_i)\\) where \\(u_i\\) is the unit vector with 1 in the \\(i\\)th location and check if vertex \\(i\\) had a degree of 1 or more than two.
-Instead, I knew that I could find the elements of \\(K(\pi)\\) with existing code and decided to check the value of \\(v\_{ik}\\) for all \\(k \in K(\pi)\\) and once it is determined that a vertex is out-of-kilter simply move on to the next vertex.
+However, I did not use the method mentioned on the paper by Held and Karp, which is to find a member of $K(\pi, u_i)$ where $u_i$ is the unit vector with 1 in the $i$th location and check if vertex $i$ had a degree of 1 or more than two.
+Instead, I knew that I could find the elements of $K(\pi)$ with existing code and decided to check the value of $v\_{ik}$ for all $k \in K(\pi)$ and once it is determined that a vertex is out-of-kilter simply move on to the next vertex.
 
 Once I have a mapping of all vertices to their kilter state, find one which is out-of-kilter and return the corresponding direction of ascent.
 
-The changes to `find_epsilon()` were very minor, basically removing the denominator from the formula for \\(\epsilon\\) and adding a check to see if we have a negative direction of ascent so that the crossover distances become positive and thus valid.
+The changes to `find_epsilon()` were very minor, basically removing the denominator from the formula for $\epsilon$ and adding a check to see if we have a negative direction of ascent so that the crossover distances become positive and thus valid.
 
 The brand new function which was needed was `branch()`, which well... branches according to the Held and Karp paper.
 The first thing it does is run the linear program to form the ascent method to determine if a direction of ascent exists.
 If the direction does exist, branch.
 If not, search the set of minimum 1-arborescences for a tour and then branch if it does not exist.
-The branch process itself is rather simple, find the first open edge (an edge not in the partition sets \\(X\\) and \\(Y\\)) and then create two new configurations where that edges is either included or excluded respectively.
+The branch process itself is rather simple, find the first open edge (an edge not in the partition sets $X$ and $Y$) and then create two new configurations where that edges is either included or excluded respectively.
 
 Finally the overall structure of the algorithm, written in pseudocode is
 
@@ -83,13 +83,13 @@ Below, the left side is the data from the Held and Karp paper and on the right m
 | Undirected Graph                                                                                               | Directed Graph                                                                                                 |
 | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | Iteration 1:                                                                                                   |
-| Starting configuration: \\((\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & 0 & 0 & 0 \end{bmatrix}, 196)\\) | Starting configuration: \\((\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & 0 & 0 & 0 \end{bmatrix}, 196)\\) |
+| Starting configuration: $(\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & 0 & 0 & 0 \end{bmatrix}, 196)$ | Starting configuration: $(\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & 0 & 0 & 0 \end{bmatrix}, 196)$ |
 | Minimum 1-Trees:                                                                                               | Minimum 1-Arborescences:                                                                                       |
 | ![minimum 1 trees](minimum-1-trees-iteration-1.png)                                                            | ![minimum 1 arborescences](minimum-1-arborescences-iteration-1.png)                                            |
 | Vertex 3 out-of-kilter LOW                                                                                     | Vertex 3 out-of-kilter LOW                                                                                     |
-| \\(d = \begin{bmatrix} 0 & 0 & 0 & -1 & 0 & 0 \end{bmatrix}\\)                                                 | \\(d = \begin{bmatrix} 0 & 0 & 0 & -1 & 0 & 0 \end{bmatrix}\\)                                                 |
-| \\(\epsilon(\pi, d) = 5\\)                                                                                     | \\(\epsilon(\pi, d) = 5\\)                                                                                     |
-| New configuration: \\((\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & -5 & 0 & 0 \end{bmatrix}, 201)\\)     | New configuration: \\((\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & -5 & 0 & 0 \end{bmatrix}, 212)\\)     |
+| $d = \begin{bmatrix} 0 & 0 & 0 & -1 & 0 & 0 \end{bmatrix}$                                                 | $d = \begin{bmatrix} 0 & 0 & 0 & -1 & 0 & 0 \end{bmatrix}$                                                 |
+| $\epsilon(\pi, d) = 5$                                                                                     | $\epsilon(\pi, d) = 5$                                                                                     |
+| New configuration: $(\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & -5 & 0 & 0 \end{bmatrix}, 201)$     | New configuration: $(\emptyset, \emptyset, \begin{bmatrix} 0 & 0 & 0 & -5 & 0 & 0 \end{bmatrix}, 212)$     |
 |                                                                                                                |
 | Iteration 2:                                                                                                   |
 | Minimum 1-Trees:                                                                                               | Minimum 1-Arborescences:                                                                                       |
@@ -178,7 +178,7 @@ Graphically, those six 1-arborescences look like this:
 
 And suddenly that mapping between the 1-trees and 1-arborescences is back!
 But why can minimum 1-arborescences come from non-minimum spanning arborescences?
-Remember that we create 1-arborescences by find spanning arborescences on the vertex set \\(\{2, 3, \dots, n\}\\) and then connecting that missing vertex to the root of the spanning arborescence and the minimum weight incoming edge.
+Remember that we create 1-arborescences by find spanning arborescences on the vertex set $\{2, 3, \dots, n\}$ and then connecting that missing vertex to the root of the spanning arborescence and the minimum weight incoming edge.
 
 This means that even among the true minimum spanning arborescences, the final weight of the 1-arborescence can vary based on the cost of connecting 'vertex 1' to the root of the arborescence.
 I already had to deal with this issue earlier in the implementation of the ascent method.
@@ -186,16 +186,16 @@ Now suppose that not every vertex in the graph is a root of an arborescence in t
 Let the _minimum_ root be the root vertex of the arborescence which is the cheapest to connect to and the _maximum_ root the root vertex which is the most expensive to connect to.
 If we needed to, we could order the roots from minimum to maximum based on the weight of the edge from 'vertex 1' to that root.
 
-Finally, suppose that the result of considering only the set of minimum spanning arborescences results in a set of minimum 1-arborescenes which do not use the minimum root and have a total cost \\(c\\) more than the cost of the minimum spanning arborescence plus the cost of connecting to the minimum root.
+Finally, suppose that the result of considering only the set of minimum spanning arborescences results in a set of minimum 1-arborescenes which do not use the minimum root and have a total cost $c$ more than the cost of the minimum spanning arborescence plus the cost of connecting to the minimum root.
 Continue to consider spanning arborescences in increasing weight, such as the ones returned by the `ArborescenceIterator`.
 Eventually the `ArborescenceIterator` will return a spanning arborescence which has the minimum root.
-If the cost of the minimum spanning arborescence is \\(c\_{min}\\) and the cost of this arborescence is less than \\(c\_{min} + c\\) then a new minimum 1-arborescence has been found from a non-minimum spanning arborescence.
+If the cost of the minimum spanning arborescence is $c\_{min}$ and the cost of this arborescence is less than $c\_{min} + c$ then a new minimum 1-arborescence has been found from a non-minimum spanning arborescence.
 
 It is obviously impractical to consider all of the spanning arborescences in the graph, and because `ArborescenceIterator` returns arborescences in order of increasing weight, there is a weight after which it is impossible to produce a minimum 1-arborescence.
 
-Let the cost of a minimum spanning arborescence be \\(c\_{min}\\) and the total costs of connecting the roots range from \\(r\_{min}\\) to \\(r\_{max}\\).
-The worst case cost of the minimum 1-arborescence is \\(c\_{min} + r\_{max}\\) which would connect the minimum spanning arborescence to the most expensive root and the best case minimum 1-arborescence would be \\(c\_{min} + r\_{min}\\).
-With regard to the weight of the spanning arborescence itself, once it exceeds \\(c\_{min} + r\_{max} - r\_{min}\\) we know that even if it uses the minimum root that the total weight will be greater than worst case minimum 1-arborescence so that is the bound which we use the `ArborescenceIterator` with.
+Let the cost of a minimum spanning arborescence be $c\_{min}$ and the total costs of connecting the roots range from $r\_{min}$ to $r\_{max}$.
+The worst case cost of the minimum 1-arborescence is $c\_{min} + r\_{max}$ which would connect the minimum spanning arborescence to the most expensive root and the best case minimum 1-arborescence would be $c\_{min} + r\_{min}$.
+With regard to the weight of the spanning arborescence itself, once it exceeds $c\_{min} + r\_{max} - r\_{min}$ we know that even if it uses the minimum root that the total weight will be greater than worst case minimum 1-arborescence so that is the bound which we use the `ArborescenceIterator` with.
 
 After implementing this boundary for checking spanning arborescences to find minimum 1-arborescences, both methods executed successfully on the test graph.
 
@@ -206,7 +206,7 @@ Surprisingly, on the test graph I have been using, which is originally from the 
 However, this six vertex graph is small and the branch and bound method may yet have better performance on larger graphs.
 I will have to create larger test graphs and then select whichever method has better performance overall.
 
-Additionally, this is an example where \\(f(\pi)\\), the gap between a tour and 1-arborescence, converges to 0.
+Additionally, this is an example where $f(\pi)$, the gap between a tour and 1-arborescence, converges to 0.
 This is not always the case, so I will need to test on an example where the minimum gap is greater than 0.
 
 Finally, the output of my Held Karp relaxation program is a tour.

--- a/content/posts/networkx/aTSP/implementing-the-iterators/index.md
+++ b/content/posts/networkx/aTSP/implementing-the-iterators/index.md
@@ -100,28 +100,28 @@ The minimum spanning arborescence initially is shown below.
 
 <center><img src="digraph-partition-msa.png" alt="Minimum spanning arborescence respecting the above partition"/></center>
 
-While the \\((3, 0)\\) edge is properly excluded and the \\((2, 3)\\) edge is included, the \\((6, 2)\\) is not present in the arborescence (show as a dashed edge).
-Tracking this problem down was a hassle, but the way that Edmonds' algorithm works is that a cycle, which would have been present if the \\((6, 2)\\) edge was included, are collapsed into a single vertex as the algorithm moves to the next iteration.
+While the $(3, 0)$ edge is properly excluded and the $(2, 3)$ edge is included, the $(6, 2)$ is not present in the arborescence (show as a dashed edge).
+Tracking this problem down was a hassle, but the way that Edmonds' algorithm works is that a cycle, which would have been present if the $(6, 2)$ edge was included, are collapsed into a single vertex as the algorithm moves to the next iteration.
 Once that cycle is collapsed into a vertex, it still has to choose how to access that vertex and the choice is based on the best edge as before (this is step I1 in [1]).
 Then, when the algorithm expands the cycle out, it will remove the edge which is
 
 - Wholly contained inside the cycle and,
 - Directed towards the vertex which is the 'access point' for the cycle.
 
-Which is this case, would be \\((6, 2)\\) shown in red in the next image.
+Which is this case, would be $(6, 2)$ shown in red in the next image.
 Represented visually, the cycle with incoming edges would look like
 
 <center><img src="digraph-cycle.png" alt="Problematic cycle with partition edges"/></center>
 
-And that would be collapsed into a new vertex, \\(N\\) from which the incoming edge with weight 12 would be selected.
+And that would be collapsed into a new vertex, $N$ from which the incoming edge with weight 12 would be selected.
 
 <center><img src="digraph-collapsed-cycle.png" alt="Same cycle after the Edmonds algorithm collapsed it"/></center>
 
-In this example we want to forbid the algorithm from picking the edge with weight 12, so that when the cycle is reconstructed the included edge \\((6, 2)\\) is still present.
+In this example we want to forbid the algorithm from picking the edge with weight 12, so that when the cycle is reconstructed the included edge $(6, 2)$ is still present.
 Once we make one of the incoming edges an included edge, we know from the definition of an arborescence that we cannot get to that vertex from any other edges.
 They are all effectively excluded, so once we find an included edge directed towards a vertex we can made all of the other incoming edges excluded.
 
-Returning to the example, the collapsed vertex \\(N\\) would have the edge of weight 12 excluded and would pick the edge of weight 13.
+Returning to the example, the collapsed vertex $N$ would have the edge of weight 12 excluded and would pick the edge of weight 13.
 
 <center><img src="digraph-collapsed-forbidden-cycle.png" alt="Solution to tracking bad cycles in the arborescence"/></center>
 
@@ -148,9 +148,9 @@ This one would check that the number of arborescences was correct and that the s
 In order to check the number of arborescecnes, I decided to take a brute force approach.
 There are
 
-\\[
+$$
 \binom{18}{8} = 43,758
-\\]
+$$
 
 possible combinations of edges which could be arborescences.
 That's a lot of combintation, more than I wanted to check by hand so I wrote a short python script.

--- a/content/posts/networkx/aTSP/looking-at-the-big-picture/index.md
+++ b/content/posts/networkx/aTSP/looking-at-the-big-picture/index.md
@@ -23,26 +23,26 @@ Recall that from the Asadpour paper the overview of the algorithm is
 
 > ---
 >
-> **Algorithm 1** An \\(O(\log n / \log \log n)\\)-approximation algorithm for the ATSP
+> **Algorithm 1** An $O(\log n / \log \log n)$-approximation algorithm for the ATSP
 >
 > ---
 >
-> **Input:** A set \\(V\\) consisting of \\(n\\) points and a cost function \\(c\ :\ V \times V \rightarrow \mathbb{R}^+\\) satisfying the triangle inequality.
+> **Input:** A set $V$ consisting of $n$ points and a cost function $c\ :\ V \times V \rightarrow \mathbb{R}^+$ satisfying the triangle inequality.
 >
-> **Output:** \\(O(\log n / \log \log n)\\)-approximation of the asymmetric traveling salesman problem instance described by \\(V\\) and \\(c\\).
+> **Output:** $O(\log n / \log \log n)$-approximation of the asymmetric traveling salesman problem instance described by $V$ and $c$.
 >
-> 1. Solve the Held-Karp LP relaxation of the ATSP instance to get an optimum extreme point solution \\(x^\*\\).
->    Define \\(z^\*\\) as in (5), making it a symmetrized and scaled down version of \\(x^\*\\).
->    Vector \\(z^\*\\) can be viewed as a point in the spanning tree polytope of the undirected graph on the support of \\(x^\*\\) that one obtains after disregarding the directions of arcs (See Section 3.)
-> 2. Let \\(E\\) be the support graph of \\(z^\*\\) when the direction of the arcs are disregarded.
->    Find weights \\(\{\tilde{\gamma}\}\_{e \in E}\\) such that the exponential distribution on the spanning trees, \\(\tilde{p}(T) \propto \exp(\sum\_{e \in T} \tilde{\gamma}\_e)\\) (approximately) preserves the marginals imposed by \\(z^\*\\), i.e. for any edge \\(e \in E\\),
->    <center>\\(\sum\_{T \in \mathcal{T} : T \ni e} \tilde{p}(T) \leq (1 + \epsilon) z^\*\_e\\),</center>
->    for a small enough value of \\(\epsilon\\).
->    (In this paper we show that \\(\epsilon = 0.2\\) suffices for our purpose. See Section 7 and 8 for a description of how to compute such a distribution.)
-> 3. Sample \\(2\lceil \log n \rceil\\) spanning trees \\(T_1, \dots, T\_{2\lceil \log n \rceil}\\) from \\(\tilde{p}(.)\\).
->    For each of these trees, orient all its edges so as to minimize its cost with respect to our (asymmetric) cost function \\(c\\).
->    Let \\(T^\*\\) be the tree whose resulting cost is minimal among all of the sampled trees.
-> 4. Find a minimum cost integral circulation that contains the oriented tree \\(\vec{T}^\*\\).
+> 1. Solve the Held-Karp LP relaxation of the ATSP instance to get an optimum extreme point solution $x^\*$.
+>    Define $z^\*$ as in (5), making it a symmetrized and scaled down version of $x^\*$.
+>    Vector $z^\*$ can be viewed as a point in the spanning tree polytope of the undirected graph on the support of $x^\*$ that one obtains after disregarding the directions of arcs (See Section 3.)
+> 2. Let $E$ be the support graph of $z^\*$ when the direction of the arcs are disregarded.
+>    Find weights $\{\tilde{\gamma}\}\_{e \in E}$ such that the exponential distribution on the spanning trees, $\tilde{p}(T) \propto \exp(\sum\_{e \in T} \tilde{\gamma}\_e)$ (approximately) preserves the marginals imposed by $z^\*$, i.e. for any edge $e \in E$,
+>    <center>$\sum\_{T \in \mathcal{T} : T \ni e} \tilde{p}(T) \leq (1 + \epsilon) z^\*\_e$,</center>
+>    for a small enough value of $\epsilon$.
+>    (In this paper we show that $\epsilon = 0.2$ suffices for our purpose. See Section 7 and 8 for a description of how to compute such a distribution.)
+> 3. Sample $2\lceil \log n \rceil$ spanning trees $T_1, \dots, T\_{2\lceil \log n \rceil}$ from $\tilde{p}(.)$.
+>    For each of these trees, orient all its edges so as to minimize its cost with respect to our (asymmetric) cost function $c$.
+>    Let $T^\*$ be the tree whose resulting cost is minimal among all of the sampled trees.
+> 4. Find a minimum cost integral circulation that contains the oriented tree $\vec{T}^\*$.
 >    Shortcut this circulation to a tour and output it. (See Section 4.)
 >
 > ---
@@ -53,7 +53,7 @@ But before we get to creating pseudo code for it there is still step 4 which nee
 
 ## Circulation and Shortcutting
 
-Once we have sampled enough spanning trees from the graph and converted the minimum one into \\(\vec{T}^\*\\) we need to find the minimum cost integral circulation in the graph which contains \\(\vec{T}^\*\\).
+Once we have sampled enough spanning trees from the graph and converted the minimum one into $\vec{T}^\*$ we need to find the minimum cost integral circulation in the graph which contains $\vec{T}^\*$.
 While NetworkX a minimum cost circulation function, namely, [`min_cost_flow`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.flow.min_cost_flow.html), it is not suitable for the Asadpour algorithm out of the box.
 The problem here is that we do not have node demands, we have edge demands.
 However, after some reading and discussion with one of my mentors Dan, we can convert the current problem into one which can be solved using the `min_cost_flow` function.
@@ -61,18 +61,18 @@ However, after some reading and discussion with one of my mentors Dan, we can co
 The problem that we are trying to solve is called the minimum cost circulation problem and the one which `min_cost_flow` is able to solve is the, well, minimum cost flow problem.
 As it happens, these are equivalent problems, so I can convert the minimum cost circulation into a minimum cost flow problem by transforming the minimum edge demands into node demands.
 
-Recall that at this point we have a directed minimum sampled spanning tree \\(\vec{T}^\*\\) and that the flow through each of the edges in \\(\vec{T}^\*\\) needs to be at least one.
-From the perspective of a flow problem, \\(\vec{T}^\*\\) is moving some flow around the graph.
-However, in order to augment \\(\vec{T}^\*\\) into an Eulerian graph so that we can walk it, we need to counteract this flow so that the net flow for each node is 0 \\((f(\delta^+(v)) = f(\delta^-(v))\\) in the Asadpour paper).
+Recall that at this point we have a directed minimum sampled spanning tree $\vec{T}^\*$ and that the flow through each of the edges in $\vec{T}^\*$ needs to be at least one.
+From the perspective of a flow problem, $\vec{T}^\*$ is moving some flow around the graph.
+However, in order to augment $\vec{T}^\*$ into an Eulerian graph so that we can walk it, we need to counteract this flow so that the net flow for each node is 0 $(f(\delta^+(v)) = f(\delta^-(v))$ in the Asadpour paper).
 
 So, we find the net flow of each node and then assign its demand to be the negative of that number so that the flow will balance at the node in question.
-If the total flow at any node \\(i\\) is \\(\delta^+(i) - \delta^-(i)\\) then the demand we assign to that node is \\(\delta^-(i) - \delta^+(i)\\).
+If the total flow at any node $i$ is $\delta^+(i) - \delta^-(i)$ then the demand we assign to that node is $\delta^-(i) - \delta^+(i)$.
 Once we assign the demands to the nodes we can temporarily ignore the edge lower capacities to find the minimum flow.
 
 For more information on the conversion process, please see [2].
 
-After the minimum flow is found, we take the support of the flow and add it to the \\(\vec{T}^\*\\) to create a multigraph \\(H\\).
-Now we know that \\(H\\) is weakly connected (it contains \\(\vec{T^\*}\\)) and that it is Eulerian because for every node the in-degree is equal to the out-degree.
+After the minimum flow is found, we take the support of the flow and add it to the $\vec{T}^\*$ to create a multigraph $H$.
+Now we know that $H$ is weakly connected (it contains $\vec{T^\*}$) and that it is Eulerian because for every node the in-degree is equal to the out-degree.
 A closed eulerian walk or eulerian circuit can be found in this graph with [`eulerian_circuit`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.euler.eulerian_circuit.html).
 
 Here is an example of this process on a simple graph.
@@ -94,7 +94,7 @@ def asadpour_tsp
     Output: A list of edges which form the approximate ATSP solution.
 ```
 
-This is exactly what we'd expect, take a complete graph \\(G\\) satisfying the triangle inequality and return the edges in the approximate solution to the asymmetric traveling salesman problem.
+This is exactly what we'd expect, take a complete graph $G$ satisfying the triangle inequality and return the edges in the approximate solution to the asymmetric traveling salesman problem.
 Recall from my post [Networkx Function Stubs]({{< relref "networkx-function-stubs" >}}) what the primary traveling salesman function, `traveling_salesman_problem` will ensure that we are given a complete graph that follows the triangle inequality by using all-pairs shortest path calculations and will handle if we are expected to return a true cycle or only a path.
 
 The first step in the Asadpour algorithm is the Held Karp relaxation.
@@ -121,7 +121,7 @@ Once we have the Held Karp solution, we create the undirected support of `z_star
 ```
 
 This completes steps 1 and 2 in the Asadpour overview at the top of this post.
-Next we sample \\(2 \lceil \log n \rceil\\) spanning trees.
+Next we sample $2 \lceil \log n \rceil$ spanning trees.
 
 ```
     for u, v in z_support.edges
@@ -136,8 +136,8 @@ Next we sample \\(2 \lceil \log n \rceil\\) spanning trees.
 ```
 
 Now that we have the minimum sampled tree, we need to orient the edge directions to keep the cost equal to that minimum tree.
-We can do this by iterating over the edges in `minimum_sampled_tree` and checking the edge weights in the original graph \\(G\\).
-Using \\(G\\) is required here if we did not record the minimum direction which is a possibility when we create `z_support`.
+We can do this by iterating over the edges in `minimum_sampled_tree` and checking the edge weights in the original graph $G$.
+Using $G$ is required here if we did not record the minimum direction which is a possibility when we create `z_support`.
 
 ```
     t_star = nx.DiGraph

--- a/content/posts/networkx/aTSP/my-summer-of-code-2021/index.md
+++ b/content/posts/networkx/aTSP/my-summer-of-code-2021/index.md
@@ -274,7 +274,7 @@ However, they were not very clear on how to calculate $q_e(\gamma)$ other than t
 
 My original method for calculating $q*e(\gamma)$ was to apply Krichhoff's Theorem to the original laplacian matrix and the laplacian produced once the edge $e$ is contracted from the graph.
 Testing quickly showed that once the edge is contracted from the graph, it cannot affect the value of the laplacian and thus after subtracting $\delta$ the probability of that edge would increase rather than decrease.
-Multiplying my original value of $q_e(\gamma)$ by $\exp(\gamma_e)$ proved to be the solution here for reasons extensively discussed in my blog post \_The Entropy Distribution* and in particular the "Update! (28 July 2021)" section.
+Multiplying my original value of $q_e(\gamma)$ by $\exp(\gamma_e)$ proved to be the solution here for reasons extensively discussed in my blog post \_The Entropy Distribution\* and in particular the "Update! (28 July 2021)" section.
 
 **Blog posts about `spanning_tree_distribution`**
 

--- a/content/posts/networkx/aTSP/my-summer-of-code-2021/index.md
+++ b/content/posts/networkx/aTSP/my-summer-of-code-2021/index.md
@@ -250,31 +250,31 @@ Annotations only provided if needed.
 
 ## `spanning_tree_distribution`
 
-Once we have the support of the Held Karp relaxation, we calculate edge weights \\(\gamma\\) for support so that the probability of any tree being sampled is proportional to the product of \\(e^{\gamma}\\) across its edges.
+Once we have the support of the Held Karp relaxation, we calculate edge weights $\gamma$ for support so that the probability of any tree being sampled is proportional to the product of $e^{\gamma}$ across its edges.
 This is called a maximum entropy distribution in the Asadpour paper.
 This procedure was included in the Asadpour paper [1] on page 386.
 
-> 1. Set \\(\gamma = \vec{0}\\).
-> 2. While there exists an edge \\(e\\) with \\(q_e(\gamma) > (1 + \epsilon)z_e\\):
+> 1. Set $\gamma = \vec{0}$.
+> 2. While there exists an edge $e$ with $q_e(\gamma) > (1 + \epsilon)z_e$:
 >
-> - Compute \\(\delta\\) such that if we define \\(\gamma'\\) ad \\(\gamma_e' = \gamma_e - \delta\\) and \\(\gamma_f' = \gamma_e\\) for all \\(f \in E \backslash \{e\}\\), then \\(q_e(\gamma') = (1 + \epsilon / 2)z_e\\)
-> - Set \\(\gamma \leftarrow \gamma'\\)
+> - Compute $\delta$ such that if we define $\gamma'$ ad $\gamma_e' = \gamma_e - \delta$ and $\gamma_f' = \gamma_e$ for all $f \in E \backslash \{e\}$, then $q_e(\gamma') = (1 + \epsilon / 2)z_e$
+> - Set $\gamma \leftarrow \gamma'$
 >
-> 3. Output \\(\tilde{\gamma} := \gamma\\).
+> 3. Output $\tilde{\gamma} := \gamma$.
 
-Where \\(q_e(\gamma)\\) is the probability that any given edge \\(e\\) will be in a sampled spanning tree chosen with probability proportional to \\(\exp(\gamma(T))\\).
-\\(\delta\\) is also given as
+Where $q_e(\gamma)$ is the probability that any given edge $e$ will be in a sampled spanning tree chosen with probability proportional to $\exp(\gamma(T))$.
+$\delta$ is also given as
 
-\\[
+$$
 \delta = \frac{q\_e(\gamma)(1-(1+\epsilon/2)z\_e)}{(1-q\_e(\gamma))(1+\epsilon/2)z\_e}
-\\]
+$$
 
 so the Asadpour paper did almost all of the heavy lifting for this function.
-However, they were not very clear on how to calculate \\(q_e(\gamma)\\) other than that Krichhoff's Tree Matrix Theorem can be used.
+However, they were not very clear on how to calculate $q_e(\gamma)$ other than that Krichhoff's Tree Matrix Theorem can be used.
 
-My original method for calculating \\(q*e(\gamma)\\) was to apply Krichhoff's Theorem to the original laplacian matrix and the laplacian produced once the edge \\(e\\) is contracted from the graph.
-Testing quickly showed that once the edge is contracted from the graph, it cannot affect the value of the laplacian and thus after subtracting \\(\delta\\) the probability of that edge would increase rather than decrease.
-Multiplying my original value of \\(q_e(\gamma)\\) by \\(\exp(\gamma_e)\\) proved to be the solution here for reasons extensively discussed in my blog post \_The Entropy Distribution* and in particular the "Update! (28 July 2021)" section.
+My original method for calculating $q*e(\gamma)$ was to apply Krichhoff's Theorem to the original laplacian matrix and the laplacian produced once the edge $e$ is contracted from the graph.
+Testing quickly showed that once the edge is contracted from the graph, it cannot affect the value of the laplacian and thus after subtracting $\delta$ the probability of that edge would increase rather than decrease.
+Multiplying my original value of $q_e(\gamma)$ by $\exp(\gamma_e)$ proved to be the solution here for reasons extensively discussed in my blog post \_The Entropy Distribution* and in particular the "Update! (28 July 2021)" section.
 
 **Blog posts about `spanning_tree_distribution`**
 
@@ -286,7 +286,7 @@ Multiplying my original value of \\(q_e(\gamma)\\) by \\(\exp(\gamma_e)\\) prove
 
 [Draft of spanning_tree_distribution](https://github.com/mjschwenne/networkx/commit/da1f5cf688277426575115e3328e16d8f5b29a3c)
 
-[Changed HK to only report on the support of the answer](https://github.com/mjschwenne/networkx/commit/b6bec0dada9ff67dc1cf28f5ae0fe3b1df490dc5) - _Needing to limit \\(\gamma\\) to only the support of the Held Karp relaxation is what caused this change_
+[Changed HK to only report on the support of the answer](https://github.com/mjschwenne/networkx/commit/b6bec0dada9ff67dc1cf28f5ae0fe3b1df490dc5) - _Needing to limit $\gamma$ to only the support of the Held Karp relaxation is what caused this change_
 
 [Fixed contraction bug by changing to MultiGraph. Problem with prob > 1](https://github.com/mjschwenne/networkx/commit/0fcf0b3ecfc3704db17830eeeae72a67b4182ffb) - _Because the probability is only_ proportional _to the product of the edge weights, this was not actually a problem_
 
@@ -294,9 +294,9 @@ Multiplying my original value of \\(q_e(\gamma)\\) by \\(\exp(\gamma_e)\\) prove
 
 [Fixed pypi test error](https://github.com/mjschwenne/networkx/commit/2195002e9394bcb2c47876809cfbbec3c05b1008) - _The pypi tests do not have `numpy` or `scipy` and I forgot to flag the test to be skipped if they are not available_
 
-[Further testing of dist fix](https://github.com/mjschwenne/networkx/commit/e4cd4f17311e8d908f016cea45f03b1b3e35822e) - _Fixed function to multiply \\(q_e(\gamma)\\) by \\(\exp(\gamma_e)\\) and implemented exception if \\(\delta\\) ever misbehaves_
+[Further testing of dist fix](https://github.com/mjschwenne/networkx/commit/e4cd4f17311e8d908f016cea45f03b1b3e35822e) - _Fixed function to multiply $q_e(\gamma)$ by $\exp(\gamma_e)$ and implemented exception if $\delta$ ever misbehaves_
 
-[Can sample spanning trees](https://github.com/mjschwenne/networkx/commit/68f0cf95565bcdce0aec4678e3af9815e23b494e) - _Streamlined finding \\(q_e(\gamma)\\) using new helper function_
+[Can sample spanning trees](https://github.com/mjschwenne/networkx/commit/68f0cf95565bcdce0aec4678e3af9815e23b494e) - _Streamlined finding $q_e(\gamma)$ using new helper function_
 
 [documentation update](https://github.com/mjschwenne/networkx/commit/837d0448d38936278cfa9fdb7d8cb636eb8552c3)
 
@@ -311,16 +311,16 @@ What good is a spanning tree distribution if we can't sample from it?
 While the Asadpour paper [1] provides a rough outline of the sampling process, the bulk of their methodology comes from the Kulkarni paper, _Generating random combinatorial objects_ [5].
 That paper had a much more detailed explanation and even this pseudo code from page 202.
 
-> \\(U = \emptyset,\\) \\(V = E\\)\
-> Do \\(i = 1\\) to \\(N\\);\
-> \\(\qquad\\)Let \\(a = n(G(U, V))\\)\
-> \\(\qquad\qquad a'\\) \\(= n(G(U \cup \{i\}, V))\\)\
-> \\(\qquad\\)Generate \\(Z \sim U[0, 1]\\)\
-> \\(\qquad\\)If \\(Z \leq \alpha_i \times \left(a' / a\right)\\)\
-> \\(\qquad\qquad\\)then \\(U = U \cup \{i\}\\),\
-> \\(\qquad\qquad\\)else \\(V = V - \{i\}\\)\
-> \\(\qquad\\)end.\
-> Stop. \\(U\\) is the required spanning tree.
+> $U = \emptyset,$ $V = E$\
+> Do $i = 1$ to $N$;\
+> $\qquad$Let $a = n(G(U, V))$\
+> $\qquad\qquad a'$ $= n(G(U \cup \{i\}, V))$\
+> $\qquad$Generate $Z \sim U[0, 1]$\
+> $\qquad$If $Z \leq \alpha_i \times \left(a' / a\right)$\
+> $\qquad\qquad$then $U = U \cup \{i\}$,\
+> $\qquad\qquad$else $V = V - \{i\}$\
+> $\qquad$end.\
+> Stop. $U$ is the required spanning tree.
 
 The only real difficulty here was tracking how the nodes were being contracted.
 My first attempt was a mess of `if` statements and the like, but switching it to a merge-find data structure (or disjoint set data structure) proved to be a wise decision.
@@ -329,9 +329,9 @@ Of course, it is one thing to be able to sample a spanning tree and another enti
 My first iteration test for `sample_spanning_tree` just sampled a large number of trees (50000) and they printed the percent error from the normalized distribution of spanning tree.
 With a sample size of 50000 all of the errors were under 10%, but I still wanted to find a better test.
 
-From my AP statistics class in high school I remembered the \\(X^2\\) (Chi-squared) test and realized that it would be perfect here.
+From my AP statistics class in high school I remembered the $X^2$ (Chi-squared) test and realized that it would be perfect here.
 `scipy` even had the ability to conduct one.
-By converting to a chi-squared test I was able to reduce the sample size down to 1200 (near the minimum required sample size to have a valid chi-squared test) and use a proper hypothesis test at the \\(\alpha = 0.01\\) significance level.
+By converting to a chi-squared test I was able to reduce the sample size down to 1200 (near the minimum required sample size to have a valid chi-squared test) and use a proper hypothesis test at the $\alpha = 0.01$ significance level.
 Unfortunately, the test would still fail 1% of the time until I added the `@py_random_state` decorator to `sample_spanning_tree`, and then the test can pass in a `Random` object to produce repeatable results.
 
 **Blog posts about `sample_spanning_tree`**
@@ -366,7 +366,7 @@ A brief overview of the whole algorithm is given below:
 
 1. Solve the Held Karp relaxation and symmertize the result to made it undirected.
 2. Calculate the maximum entropy spanning tree distribution on the Held Karp support graph.
-3. Sample \\(2 \lceil \ln n \rceil\\) spanning trees and record the smallest weight one before reintroducing direction to the edges.
+3. Sample $2 \lceil \ln n \rceil$ spanning trees and record the smallest weight one before reintroducing direction to the edges.
 4. Find the minimum cost circulation to create an eulerian graph containing the sampled tree.
 5. Take the eulerian walk of that graph and shortcut the answer.
 6. return the shortcut answer.

--- a/content/posts/networkx/aTSP/networkx-function-stubs/index.md
+++ b/content/posts/networkx/aTSP/networkx-function-stubs/index.md
@@ -65,7 +65,7 @@ def traveling_salesman_problem(G, weight="weight", nodes=None, cycle=True, metho
 
 All user calls to find an approximation to the traveling salesman problem will go through this function.
 My implementation of the Asadpour algorithm will also need to be compatible with this function.
-`traveling_salesman_problem` will handle creating a new, complete graph using the weight of the shortest path between nodes \\(u\\) and \\(v\\) as the weight of that arc, so we know that by the time the graph is passed to the Asadpour algorithm it is a complete digraph which satisfies the triangle inequality.
+`traveling_salesman_problem` will handle creating a new, complete graph using the weight of the shortest path between nodes $u$ and $v$ as the weight of that arc, so we know that by the time the graph is passed to the Asadpour algorithm it is a complete digraph which satisfies the triangle inequality.
 The main function also handles the `nodes` and `cycles` parameters by only copying the necessary nodes into the complete digraph before calling the requested method and afterwards searching for and removing the largest arc within the returned cycle.
 Thus, the parent function for the Asadpour algorithm only needs to deal with the graph itself and the weights or costs of the arcs in the graph.
 
@@ -125,25 +125,25 @@ Solving the Held-Karp relaxation is the first step in the algorithm.
 
 Recall that the Held-Karp relaxation is defined as the following linear program:
 
-\\[
+$$
 \begin{array}{c l l}
 \text{min} & \sum_{a} c(a)x_a \\\\\\
 \text{s.t.} & x(\delta^+(U)) \geqslant 1 & \forall\ U \subset V \text{ and } U \not= \emptyset \\\\\\
 & x(\delta^+(v)) = x(\delta^-(v)) = 1 & \forall\ v \in V \\\\\\
 & x_a \geqslant 0 & \forall\ a
 \end{array}
-\\]
+$$
 
 and that it is a semi-infinite program so it is too large to be solved in conventional forms.
-The algorithm uses the solution to the Held-Karp relaxation to create a vector \\(z^\*\\) which is a symmetrized and slightly scaled down version of the true Held-Karp solution \\(x^\*\\).
-\\(z^\*\\) is defined as
+The algorithm uses the solution to the Held-Karp relaxation to create a vector $z^\*$ which is a symmetrized and slightly scaled down version of the true Held-Karp solution $x^\*$.
+$z^\*$ is defined as
 
-\\[
+$$
 z^\*\_{\{u, v\}} = \frac{n - 1}{n} \left(x^\*\_{uv} + x^\*\_{vu}\right)
-\\]
+$$
 
 and since this is what the algorithm using to build the rest of the approximation, this should be one of the return values from `held_karp`.
-I will also return the value of the cost of \\(x^\*\\), which is denoted as \\(c(x^\*)\\) or \\(OPT\_{HK}\\) in the Asadpour paper [1].
+I will also return the value of the cost of $x^\*$, which is denoted as $c(x^\*)$ or $OPT\_{HK}$ in the Asadpour paper [1].
 
 Additionally, the separation oracle will be defined as an inner function within `held_karp`.
 At the present moment I am not sure what the exact parameters for the separation oracle, `sep_oracle`, but it should be the the point the algorithm wishes to test and will need to access the graph the algorithm is relaxing.
@@ -251,7 +251,7 @@ def _spanning_tree_distribution(z_star):
 ```
 
 Now that the algorithm has the distribution of spanning trees, we need to sample them.
-Each sampled tree is a \\(\lambda\\)-random tree and can be sampled using algorithm A8 in [2].
+Each sampled tree is a $\lambda$-random tree and can be sampled using algorithm A8 in [2].
 
 ```python
 def _sample_spanning_tree(G, gamma):
@@ -332,7 +332,7 @@ Which is exactly what I need, _except_ the decorator states that it does not sup
 Fortunately, our distribution of spanning trees is for trees in a directed graph _once the direction is disregarded_, so we can actually use the existing function.
 The definition given in the Asadpour paper [1], is
 
-\\[
+$$
 L\_{i,j} = \left\\{
 \begin{array}{l l}
 -\lambda\_e & e = (i, j) \in E \\\\\\
@@ -340,9 +340,9 @@ L\_{i,j} = \left\\{
 0 & \text{otherwise}
 \end{array}
 \right.
-\\]
+$$
 
-Where \\(E\\) is defined as "Let \\(E\\) be the support of graph of \\(z^\*\\) when the direction of the arcs are disregarded" on page 5 of the Asadpour paper.
+Where $E$ is defined as "Let $E$ be the support of graph of $z^\*$ when the direction of the arcs are disregarded" on page 5 of the Asadpour paper.
 Thus, I can use the existing method without having to create a new one, which will save time and effort on this GSoC project.
 
 In addition to being discussed here, these function stubs have been added to my fork of `NetworkX` on the `bothTSP` branch.

--- a/content/posts/networkx/aTSP/preliminaries-for-sampling-a-spanning-tree/index.md
+++ b/content/posts/networkx/aTSP/preliminaries-for-sampling-a-spanning-tree/index.md
@@ -43,7 +43,7 @@ Immediately we can see that $\mathfrak{B}$ is the same as $\mathcal{T}$ from the
 The weight of each edge is $\alpha_i$ for Kulkarni and $\lambda_e$ to Asadpour.
 As for the product of the weights of the graph being the probability, the Asadpour paper states on page 382
 
-> Given $\lambda*e \geq 0$ for $e \in E$, a $\lambda$*-random tree\_ $T$ of $G$ is a tree $T$ chosen from the set of all spanning trees of $G$ with probability proportional to $\prod\_{e \in T} \lambda_e$.
+> Given $\lambda*e \geq 0$ for $e \in E$, a $\lambda$\*-random tree\_ $T$ of $G$ is a tree $T$ chosen from the set of all spanning trees of $G$ with probability proportional to $\prod\_{e \in T} \lambda_e$.
 
 So this is not a concern.
 Finally, $n(G)$ can be written as

--- a/content/posts/networkx/aTSP/preliminaries-for-sampling-a-spanning-tree/index.md
+++ b/content/posts/networkx/aTSP/preliminaries-for-sampling-a-spanning-tree/index.md
@@ -24,31 +24,31 @@ While I was not able to find an online copy of this article, the Michigan Tech l
 Kulkarni gave a general overview of the algorithm in Section 2, but Section 5 is titled `Random Spanning Trees' and starts on page 200.
 First, let's check that the preliminaries for the Kulkarni paper on page 200 match the Asadpour algorithm.
 
-> Let \\(G = (V, E)\\) be an undirected network of \\(M\\) nodes and \\(N\\) arcs...
-> Let \\(\mathfrak{B}\\) be the set of all spanning trees in \\(G\\).
-> Let \\(\alpha_i\\) be the positive weight of arc \\(i \in E\\).
-> Defined the weight \\(w(B)\\) of a spanning tree \\(B \in \mathfrak{B}\\) as
+> Let $G = (V, E)$ be an undirected network of $M$ nodes and $N$ arcs...
+> Let $\mathfrak{B}$ be the set of all spanning trees in $G$.
+> Let $\alpha_i$ be the positive weight of arc $i \in E$.
+> Defined the weight $w(B)$ of a spanning tree $B \in \mathfrak{B}$ as
 >
-> \\[w(B) = \prod\_{i \in B} \alpha\_i\\]
+> $$w(B) = \prod\_{i \in B} \alpha\_i$$
 >
 > Also define
 >
-> \\[n(G) = \sum\_{B \in \mathfrak{B}} w(B)\\]
+> $$n(G) = \sum\_{B \in \mathfrak{B}} w(B)$$
 >
-> In this section we describe an algorithm to generate \\(B \in \mathfrak{B}\\) so that
+> In this section we describe an algorithm to generate $B \in \mathfrak{B}$ so that
 >
-> \\[P\\{B \text{ is generated}\\} = \frac{w(B)}{n(G)}\\]
+> $$P\\{B \text{ is generated}\\} = \frac{w(B)}{n(G)}$$
 
-Immediately we can see that \\(\mathfrak{B}\\) is the same as \\(\mathcal{T}\\) from the Asadpour paper, the set of all spanning trees.
-The weight of each edge is \\(\alpha_i\\) for Kulkarni and \\(\lambda_e\\) to Asadpour.
+Immediately we can see that $\mathfrak{B}$ is the same as $\mathcal{T}$ from the Asadpour paper, the set of all spanning trees.
+The weight of each edge is $\alpha_i$ for Kulkarni and $\lambda_e$ to Asadpour.
 As for the product of the weights of the graph being the probability, the Asadpour paper states on page 382
 
-> Given \\(\lambda*e \geq 0\\) for \\(e \in E\\), a \\(\lambda\\)*-random tree\_ \\(T\\) of \\(G\\) is a tree \\(T\\) chosen from the set of all spanning trees of \\(G\\) with probability proportional to \\(\prod\_{e \in T} \lambda_e\\).
+> Given $\lambda*e \geq 0$ for $e \in E$, a $\lambda$*-random tree\_ $T$ of $G$ is a tree $T$ chosen from the set of all spanning trees of $G$ with probability proportional to $\prod\_{e \in T} \lambda_e$.
 
 So this is not a concern.
-Finally, \\(n(G)\\) can be written as
+Finally, $n(G)$ can be written as
 
-\\[\sum\_{T \in \mathcal{T}} \prod\_{e \in T} \lambda\_e\\]
+$$\sum\_{T \in \mathcal{T}} \prod\_{e \in T} \lambda\_e$$
 
 which does appear several times throughout the Asadpour paper.
 Thus the preliminaries between the Kulkarni and Asadpour papers align.
@@ -57,48 +57,48 @@ Thus the preliminaries between the Kulkarni and Asadpour papers align.
 
 The specialized version of the general algorithm which Kulkarni gives is Algorithm A8 on page 202.
 
-> \\(U = \emptyset,\\) \\(V = E\\)\
-> Do \\(i = 1\\) to \\(N\\);\
-> \\(\qquad\\)Let \\(a = n(G(U, V))\\)\
-> \\(\qquad\qquad a'\\) \\(= n(G(U \cup \{i\}, V))\\)\
-> \\(\qquad\\)Generate \\(Z \sim U[0, 1]\\)\
-> \\(\qquad\\)If \\(Z \leq \alpha_i \times \left(a' / a\right)\\)\
-> \\(\qquad\qquad\\)then \\(U = U \cup \{i\}\\),\
-> \\(\qquad\qquad\\)else \\(V = V - \{i\}\\)\
-> \\(\qquad\\)end.\
-> Stop. \\(U\\) is the required spanning tree.
+> $U = \emptyset,$ $V = E$\
+> Do $i = 1$ to $N$;\
+> $\qquad$Let $a = n(G(U, V))$\
+> $\qquad\qquad a'$ $= n(G(U \cup \{i\}, V))$\
+> $\qquad$Generate $Z \sim U[0, 1]$\
+> $\qquad$If $Z \leq \alpha_i \times \left(a' / a\right)$\
+> $\qquad\qquad$then $U = U \cup \{i\}$,\
+> $\qquad\qquad$else $V = V - \{i\}$\
+> $\qquad$end.\
+> Stop. $U$ is the required spanning tree.
 
 Now we have to understand this algorithm so we can create pseudo code for it.
-First as a notational explanation, the statement "Generate \\(Z \sim U[0, 1]\\)" means picking a uniformly random variable over the interval \\([0, 1]\\) which is independent of all the random variables generated before it (See page 188 of Kulkarni for more information).
+First as a notational explanation, the statement "Generate $Z \sim U[0, 1]$" means picking a uniformly random variable over the interval $[0, 1]$ which is independent of all the random variables generated before it (See page 188 of Kulkarni for more information).
 The built-in python module [`random`](https://docs.python.org/3/library/random.html) can be used here.
 Looking at real-valued distributions, I believe that using `random.uniform(0, 1)` is preferable to `random.random()` since the latter does not have the probability of generating a '1' and that is explicitly part of the interval discussed in the Kulkarni paper.
 
-The other notational oddity would be statements similar to \\(G(U, V)\\) which is this case does not refer to a graph with \\(U\\) as the vertex set and \\(V\\) as the edge set as \\(U\\) and \\(V\\) are both subsets of the full edge set \\(E\\).
+The other notational oddity would be statements similar to $G(U, V)$ which is this case does not refer to a graph with $U$ as the vertex set and $V$ as the edge set as $U$ and $V$ are both subsets of the full edge set $E$.
 
-\\(G(U, V)\\) is defined in the Kulkarni paper on page 201 as
+$G(U, V)$ is defined in the Kulkarni paper on page 201 as
 
-> Let \\(G(U, V)\\) be a subgraph of \\(G\\) obtained by deleting arcs that are not in \\(V\\), and collapsing arcs that are in \\(U\\) (i.e., identifying the end nodes of arcs in \\(U\\)) and deleting all self-loops resulting from these deletions and collapsing.
+> Let $G(U, V)$ be a subgraph of $G$ obtained by deleting arcs that are not in $V$, and collapsing arcs that are in $U$ (i.e., identifying the end nodes of arcs in $U$) and deleting all self-loops resulting from these deletions and collapsing.
 
-This language seems a bit... clunky, especially for the edges in \\(U\\).
-In this case, "collapsing arcs that are in \\(U\\)" would be contracting those edges without self loops.
+This language seems a bit... clunky, especially for the edges in $U$.
+In this case, "collapsing arcs that are in $U$" would be contracting those edges without self loops.
 Fortunately, this functionality is a part of NetworkX using [`networkx.algorithms.minors.contracted_edge`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.minors.contracted_edge.html#networkx.algorithms.minors.contracted_edge) with the `self_loops` keyword argument set to `False`.
 
-As for the edges in \\(E - V\\), this can be easily accomplished by using [`networkx.MultiGraph.remove_edges_from`](https://networkx.org/documentation/stable/reference/classes/generated/networkx.MultiGraph.remove_edges_from.html).
+As for the edges in $E - V$, this can be easily accomplished by using [`networkx.MultiGraph.remove_edges_from`](https://networkx.org/documentation/stable/reference/classes/generated/networkx.MultiGraph.remove_edges_from.html).
 
-Once we have generated \\(G(U, V)\\), we need to find \\(n(G(U, V)\\).
+Once we have generated $G(U, V)$, we need to find $n(G(U, V)$.
 This can be done with something we are already familiar with: Kirchhoff's Tree Matrix Theorem.
 All we need to do is create the Laplacian matrix and then find the determinant of the first cofactor.
 This code will probably be taken directly from the `spanning_tree_distribution` function.
 Actually, this is a place to create a broader helper function called `krichhoffs` which will take a graph and return the number of weighted spanning trees in it which would then be used as part of `q` in `spanning_tree_distribution` and in `sample_spanning_tree`.
 
-From here we compare \\(Z\\) to \\(\alpha_i \left(a' / a\right)\\) so see if that edge is added to the graph or discarded.
-Understanding the process of the algorithm gives context to the meaning of \\(U\\) and \\(V\\).
-\\(U\\) is the set of edges which we have decided to include in the spanning tree while \\(V\\) is the set of edges yet to be considered for \\(U\\) (roughly speaking).
+From here we compare $Z$ to $\alpha_i \left(a' / a\right)$ so see if that edge is added to the graph or discarded.
+Understanding the process of the algorithm gives context to the meaning of $U$ and $V$.
+$U$ is the set of edges which we have decided to include in the spanning tree while $V$ is the set of edges yet to be considered for $U$ (roughly speaking).
 
-Now there is still a bit of ambiguity in the algorithm that Kulkarni gives, mainly about \\(i\\).
-In the loop condition, \\(i\\) is an integer from 1 to \\(N\\), the number of arcs in the graph but it is later being added to \\(U\\) so it has to be an edge.
-Referencing the Asadpour paper, it starts its description of sampling the \\(\lambda\\)-random tree on page 383 by saying "The idea is to order the edges \\(e_1, \dots, e_m\\) of \\(G\\) arbitrarily and process them one by one".
-So I believe that the edge interpretation is correct and the integer notation used in Kulkarni was assuming that a mapping of the edges to \\(\{1, 2, \dots, N\}\\) has occurred.
+Now there is still a bit of ambiguity in the algorithm that Kulkarni gives, mainly about $i$.
+In the loop condition, $i$ is an integer from 1 to $N$, the number of arcs in the graph but it is later being added to $U$ so it has to be an edge.
+Referencing the Asadpour paper, it starts its description of sampling the $\lambda$-random tree on page 383 by saying "The idea is to order the edges $e_1, \dots, e_m$ of $G$ arbitrarily and process them one by one".
+So I believe that the edge interpretation is correct and the integer notation used in Kulkarni was assuming that a mapping of the edges to $\{1, 2, \dots, N\}$ has occurred.
 
 ## sample_spanning_tree pseudo code
 
@@ -120,7 +120,7 @@ Next up is a bit of initialization
 ```
 
 Now the definitions of `U` and `V` come directly from Algorithm A8, but `shuffled_edges` is new.
-My thoughts are that this will be what we use for \\(i\\).
+My thoughts are that this will be what we use for $i$.
 We shuffle the edges of the graph and then in the loop we iterate over the edges within `shuffled_edges`.
 Next we have the loop.
 

--- a/content/posts/networkx/aTSP/sampling-a-spanning-tree/index.md
+++ b/content/posts/networkx/aTSP/sampling-a-spanning-tree/index.md
@@ -27,7 +27,7 @@ It followed exactly from the pesudo code and was working with `spanning_tree_dis
 
 This function was more difficult than I originally anticipated.
 The code for the main body of the function only needed minor tweaks to work with the specifics of python such as `shuffle` being in place and returning `None` and some details about how sets work.
-For example, I add edge \\(e\\) to \\(U\\) before calling `prepare_graph` on in and then switch the `if` statement to be the inverse to remove \\(e\\) from \\(U\\).
+For example, I add edge $e$ to $U$ before calling `prepare_graph` on in and then switch the `if` statement to be the inverse to remove $e$ from $U$.
 Those portions are functionally the same.
 The issues I had with this function _all_ stem back to contracting multiple nodes in a row and how that affects the graph.
 
@@ -42,13 +42,13 @@ I struggled with NetworkX's API about the graph classes in a past post titled [T
 
 For NetworkX's implementation, we would call `nx.contracted_nodes(G, u, v)` and `u` and `v` would always be merged into `u`, so `v` is the node which is no longer in the graph.
 
-Now imagine that we have three edges to contract because they are all in \\(U\\) which look like the following.
+Now imagine that we have three edges to contract because they are all in $U$ which look like the following.
 
 <center><img src="multiple-contraction.png" alt="Example subgraph with multiple edges to contract"></center>
 
 If we process this from left to right, we first contract nodes 0 and 1.
-At this point, the \\(\\{1, 2\\}\\) no longer exists in \\(G\\) as node 1 itself has been removed.
-However, we would still need to contract the new \\(\\{0, 2\\}\\) edge which is equivalent to the old \\(\\{1, 2\\}\\) edge.
+At this point, the $\\{1, 2\\}$ no longer exists in $G$ as node 1 itself has been removed.
+However, we would still need to contract the new $\\{0, 2\\}$ edge which is equivalent to the old $\\{1, 2\\}$ edge.
 
 My first attempt to solve this was... messy and didn't work well.
 I developed an `if-elif` chain for which endpoints of the contracting edge no longer existed in the graph and tried to use dict comprehension to force a dict to always be up to date with which vertices were equivalent to each other.
@@ -59,7 +59,7 @@ This next bit of code I actually first used in my Graph Algorithms class from la
 In particular it is the merge-find or disjoint set data structure from the components algorithm (code can be found [here](https://github.com/mjschwenne/GraphAlgorithms/blob/main/src/Components.py) and more information about the data structure [here](https://en.wikipedia.org/wiki/Disjoint-set_data_structure)).
 
 Basically we create a mapping from a node to that node's representative.
-In this case a node's representative is the node that is still in \\(G\\) but the input node has been merged into through a series of contractions.
+In this case a node's representative is the node that is still in $G$ but the input node has been merged into through a series of contractions.
 In the above example, once node 1 is merged into node 0, 0 would become node 1's representative.
 We search recursively through the `merged_nodes` dict until we find a node which is not in the dict, meaning that it is still its own representative and therefore in the graph.
 This will let us handle a representative node later being merged into another node.
@@ -72,27 +72,27 @@ I was testing on the symmetric fractional Held Karp graph by the way, so with si
 I seeded the random number generator for one of the seven edge results and started to debug!
 Recall that once we generate a uniform decimal between 0 and 1 we compare it to
 
-\\[
+$$
 \lambda\_e \times \frac{K\_{G \backslash \{e\}}}{K\_G}
-\\]
+$$
 
-where \\(K\\) is the result of Krichhoff's Theorem on the subscripted graph.
+where $K$ is the result of Krichhoff's Theorem on the subscripted graph.
 One probability that caught my eye had the fractional component equal to 1.
-This means that adding \\(e\\) to the set of contracted edges had no effect on where that edge should be included in the final spanning tree.
-Closer inspection revealed that the edge \\(e\\) in question already could not be picked for the spanning tree since it did not exist in \\(G\\) it could not exist in \\(G \backslash \{e\}\\).
+This means that adding $e$ to the set of contracted edges had no effect on where that edge should be included in the final spanning tree.
+Closer inspection revealed that the edge $e$ in question already could not be picked for the spanning tree since it did not exist in $G$ it could not exist in $G \backslash \{e\}$.
 
 Imagine the following situation.
 We have three edges to contract but they form a cycle of length three.
 
 <center><img src="contraction-cycle.png" alt="Example of the contraction of a cycle in a subgraph"></center>
 
-If we contract \\(\\{0, 1\\}\\) and then \\(\\{0, 2\\}\\) what does that mean for \\(\\{1, 2\\}\\)?
-Well, \\(\{1, 2\}\\) would become a self loop on vertex 0 but we are deleting self loops so it cannot exist.
+If we contract $\\{0, 1\\}$ and then $\\{0, 2\\}$ what does that mean for $\\{1, 2\\}$?
+Well, $\{1, 2\}$ would become a self loop on vertex 0 but we are deleting self loops so it cannot exist.
 It has to have a probability of 0.
-Yet in the current implementation of the function, it would have a probability of \\(\lambda\_{\\{1, 2\\}}\\).
+Yet in the current implementation of the function, it would have a probability of $\lambda\_{\\{1, 2\\}}$.
 So, I have to check to see if a representative edge exists for the edge we are considering in the current iteration of the main for loop.
 
-The solution to this is to return the merge-find data structure with the prepared graph for \\(G\\) and then check that an edge with endpoints at the two representatives for the endpoints of the original edge exists.
+The solution to this is to return the merge-find data structure with the prepared graph for $G$ and then check that an edge with endpoints at the two representatives for the endpoints of the original edge exists.
 If so, use the kirchhoff value as normal but if not make `G_e_total_tree_weight` equal to zero so that this edge cannot be picked.
 Finally I was able to sample trees from `G` consistently, but did they match the expected probabilities?
 

--- a/content/posts/networkx/aTSP/understanding-the-ascent-method/index.md
+++ b/content/posts/networkx/aTSP/understanding-the-ascent-method/index.md
@@ -22,9 +22,9 @@ My mentors and I agreed that the branch and bound method discussed in Held and K
 For the last week and a half I have been implementing and debugging the ascent method and wanted to take some time to reflect on what I have learned.
 
 I will start by saying that as of the writing of this post, my version of the ascent method is not giving what I expect to be the optimal solution.
-For my testing, I took the graph which Held and Karp use in their example of the branch and bound method, a weighted \\(\mathcal{K}\_6\\), and converted to a directed but symmetric version given in the following adjacency matrix.
+For my testing, I took the graph which Held and Karp use in their example of the branch and bound method, a weighted $\mathcal{K}\_6$, and converted to a directed but symmetric version given in the following adjacency matrix.
 
-\\[
+$$
 \begin{bmatrix}
 0 & 97 & 60 & 73 & 17 & 52 \\\\\\
 97 & 0 & 41 & 52 & 90 & 30 \\\\\\
@@ -33,7 +33,7 @@ For my testing, I took the graph which Held and Karp use in their example of the
 17 & 90 & 35 & 95 & 0 & 81 \\\\\\
 52 & 30 & 41 & 46 & 81 & 0
 \end{bmatrix}
-\\]
+$$
 
 The original solution is an undirected tour but in the directed version, the expected solutions depend on which way they are traversed.
 Both of these cycles have a total weight of 207.
@@ -56,7 +56,7 @@ I stated that
 > In order to connect vertex 1, we would choose the outgoing arc with the smallest cost and the incoming arc with the smallest cost.
 
 In reality, this method would produce graphs which are almost arborescences based solely on the fact that the outgoing arc would almost certainly create a vertex with two incoming arcs.
-Instead, we need to connect vertex 1 with the incoming edge of lowest cost and the edge connecting to the root node of the arborescence on nodes \\(\{2, 3, \dots, n\}\\) that way the in-degree constraint is not violated.
+Instead, we need to connect vertex 1 with the incoming edge of lowest cost and the edge connecting to the root node of the arborescence on nodes $\{2, 3, \dots, n\}$ that way the in-degree constraint is not violated.
 
 For the test graph on the first iteration of the ascent method, `k_pi()` returned 10 1-arborescences but the costs were not all the same.
 Notice that because we have no agency in choosing the outgoing edge of vertex 1 that the total cost of the 1-arborescence will vary by the difference between the cheapest root to connect to and the most expensive node to connect to.
@@ -163,26 +163,26 @@ Either way, the fact that I had almost entirely re-written this function without
 
 This was the one function which has pseudocode in the Held and Karp paper:
 
-> 1. Set \\(d\\) equal to the zero \\(n\\)-vector.
-> 2. Find a 1-tree \\(T^k\\) such that \\(k \in K(\pi, d)\\). [A method of executing Step 2 follows from the results of Section 6 (the greedy algorithm).]
-> 3. If \\(\sum\_{i=1}^{i=n} d_i v\_{i k} > 0\\), STOP.
-> 4. \\(d_i \rightarrow d_i + v\_{i k}\\), for \\(i = 2, 3, \dots, n\\)
+> 1. Set $d$ equal to the zero $n$-vector.
+> 2. Find a 1-tree $T^k$ such that $k \in K(\pi, d)$. [A method of executing Step 2 follows from the results of Section 6 (the greedy algorithm).]
+> 3. If $\sum\_{i=1}^{i=n} d_i v\_{i k} > 0$, STOP.
+> 4. $d_i \rightarrow d_i + v\_{i k}$, for $i = 2, 3, \dots, n$
 > 5. GO TO 2.
 
 Using this as a guide, the implementation of this function was simple until I got to the terminating condition, which is a linear program discussed on page 1149 as
 
-> Thus, when failure to terminate is suspected, it is necessary to check whether no direction of ascent exists; by the Minkowski-Farkas lemma this is equivalent to the existence of nonnegative coefficients \\(\alpha_k\\) such that
+> Thus, when failure to terminate is suspected, it is necessary to check whether no direction of ascent exists; by the Minkowski-Farkas lemma this is equivalent to the existence of nonnegative coefficients $\alpha_k$ such that
 >
-> \\( \sum\_{k \in K(\pi)} \alpha_kv\_{i k} = 0, \quad i = 1, 2, \dots, n \\)
+> $ \sum\_{k \in K(\pi)} \alpha_kv\_{i k} = 0, \quad i = 1, 2, \dots, n $
 >
 > This can be checked by linear programming.
 
 While I was able to implement this without much issue, one _very_ important constraint of the linear program was not mentioned here, but rather the page before during a proof.
 That constraint is
 
-\\[
+$$
 \sum\_{k \in K(\pi)} \alpha\_k = 1
-\\]
+$$
 
 Once I spent several hours trying to debug the original linear program and noticed the missing constraint. The linear program started to behave correctly, terminating the program when a tour is found.
 
@@ -193,13 +193,13 @@ This function requires a completely different implementation compared to the one
 The basic idea in both my implementation for directed graphs and the description for undirected graphs is finding edges which are substitutes for each other, or an edge outside the 1-arborescence which can replace an edge in the arborescence and will result in a 1-arborescence.
 
 The undirected version uses the idea of fundamental cycles in the tree to find the substitutes, and I tried to use this idea as will with the [`find_cycle()`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.cycles.find_cycle.html) function in the NetworkX library.
-I executed the first iteration of the ascent method by hand and noticed that what I computed for all of the possible values of \\(\epsilon\\) and what the program found did not match.
+I executed the first iteration of the ascent method by hand and noticed that what I computed for all of the possible values of $\epsilon$ and what the program found did not match.
 I had found several that it had missed and it found several that I missed.
 For the example graph, I found that the following edge pairs are substitutes where the first edge is not in the 1-arborescence and the second one is the one in the 1-arborescence which it can replace using the below minimum 1-arborescence.
 
 <center><img src="minimum-1-arborescence.png" width=350 alt="1-arborescence after the first iteration of the ascent method"/></center>
 
-\\[
+$$
 \begin{array}{l}
 (0, 1) \rightarrow (2, 1) \text{ valid: } \epsilon = 56 \\\\\\
 (0, 2) \rightarrow (4, 2) \text{ valid: } \epsilon = 25 \\\\\\
@@ -214,11 +214,11 @@ For the example graph, I found that the following edge pairs are substitutes whe
 (4, 5) \rightarrow (1, 5) \text{ valid: } \epsilon = -25.5 \text{, not valid (negative }\epsilon) \\\\\\
 (5, 3) \rightarrow (2, 3) \text{ valid: } \epsilon = 25 \\\\\\
 \end{array}
-\\]
+$$
 
 I missed the following substitutes which the program did find.
 
-\\[
+$$
 \begin{array}{l}
 (1, 0) \rightarrow (4, 0) \text{ valid: } \epsilon = 80 \\\\\\
 (1, 4) \rightarrow (0, 4) \text{ valid: } \epsilon = 73 \\\\\\
@@ -229,22 +229,22 @@ I missed the following substitutes which the program did find.
 (5, 0) \rightarrow (4, 0) \text{ valid: } \epsilon = 35 \\\\\\
 (5, 4) \rightarrow (0, 4) \text{ valid: } \epsilon = \frac{17 - 81}{0 - 0} \text{, not valid} \\\\\\
 \end{array}
-\\]
+$$
 
 Notice that some substitutions do not cross over if we move in the direction of ascent, which are the pairs which have a zero as the denominator.
-Additionally, \\(\epsilon\\) is a distance, and the concept of a negative distance does not make sense.
+Additionally, $\epsilon$ is a distance, and the concept of a negative distance does not make sense.
 Interpreting a negative distance as a positive distance in the opposite direction, if we needed to move in that direction, the direction of ascent vector would be pointing the other way.
 
 The reason that my list did not match the list of the program was because `find_cycle()` did not always return the fundamental cycle containing the new edge.
-If I called `find_cycle()` on a vertex in the other cycle in the graph (in this case \\(\{(0, 4), (4, 0)\}\\)), it would return that rather than the true fundamental cycle.
+If I called `find_cycle()` on a vertex in the other cycle in the graph (in this case $\{(0, 4), (4, 0)\}$), it would return that rather than the true fundamental cycle.
 
 This prompted me to think about what really determines if edges in a 1-arborescence are substitutes for each other.
 In every case where a substitute was valid, both of those edges lead to the same vertex.
 If they did not, then the degree constraint of the arborescence would be violated because we did not replace the edge leading into a node with another edge leading into the same node.
 This is true regardless of if the edges are part of the same fundamental cycle or not.
 
-Thus, `find_epsilon()` now takes every edge in the graph but not the chosen 1-arborescence \\(k \in K(\pi, d)\\) and find the other edge in \\(k\\) pointing to the same vertex, swaps them and then checks that the degree constraint is not violated, it has the correct number of edges and it is still connected.
-This is a more efficient method to use, and it found more valid substitutions as well so I was hopeful that it would finally bring the returned solution down to the optimal solution, perhaps because it was missing the correct value of \\(\epsilon\\) on even just one of the iterations.
+Thus, `find_epsilon()` now takes every edge in the graph but not the chosen 1-arborescence $k \in K(\pi, d)$ and find the other edge in $k$ pointing to the same vertex, swaps them and then checks that the degree constraint is not violated, it has the correct number of edges and it is still connected.
+This is a more efficient method to use, and it found more valid substitutions as well so I was hopeful that it would finally bring the returned solution down to the optimal solution, perhaps because it was missing the correct value of $\epsilon$ on even just one of the iterations.
 
 It did not.
 


### PR DESCRIPTION
Currently, all of the math rendering is broken on the asymmetric traveling salesperson posts. I believe this is due to using `\[`, `\]`, `\(` and `\)` for math delimitiers. I've updated them to use `$` and `$$`.

![image](https://github.com/scientific-python/blog.scientific-python.org/assets/19698215/174c0965-cb81-469c-8279-aa31ca4e5a7a)

