### PR TITLE
Disable relative URLs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,6 @@ baseURL: "https://blog.scientific-python.org/"
 languageCode: "en-us"
 title: "Blog"
 theme: scientific-python-hugo-theme
-relativeURLs: true
 disableKinds: ["RSS", "taxonomy"]
 ignoreErrors: ["error-disable-taxonomy"]
 


### PR DESCRIPTION
Not sure why we enabled this. But my understanding is this is not recommended.

It states here https://gohugo.io/content-management/urls/#relative-urls
```
Do not enable this option unless you are creating a serverless site, navigable via the file system.
```

<!--
Thanks for contributing a pull request!

For more information on how to submit:

https://blog.scientific-python.org/submitting/

Note that we are a team of volunteers; we appreciate your
patience during the review process. For more information:

https://blog.scientific-python.org/reviewing/

Again, thanks for contributing!
-->

- [ ] The main subject relates to at least one project affiliated to the Scientific Python Ecosystem.
- [ ] I have the right to publish the content under BSD 3-Clause License for the code and Creative Common CC-BY-4.0 License for the text.
- [ ] Images have been compressed using a tool like `pngquant`.
