### PR TITLE
Give a name to the index page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title:
+title: Scientific Python
 ---
 
 {{< grid columns="1 2 2 2" >}}


### PR DESCRIPTION
Otherwise, the title renders "Blog - " (compared to "Blog - Scientific Python" after this PR.