### PR TITLE
Add Lato font

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,10 @@ params:
     discourse_url: https://discuss.scientific-python.org/
   images:
     - /images/logo.svg
+  fonts:
+    - name: "Lato"
+      weights: [400, 700]
+
   navbarlogo:
     image: logo.svg
     text: Scientific Python Blog


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

For more information on how to submit:

https://blog.scientific-python.org/submitting/

Note that we are a team of volunteers; we appreciate your
patience during the review process. For more information:

https://blog.scientific-python.org/reviewing/

Again, thanks for contributing!
-->

| Before | After |
|--------|--------|
| <img width="267" height="59" alt="image" src="https://github.com/user-attachments/assets/4259a6bd-7afa-4854-aa5b-51dab81726f2" /> | <img width="280" height="59" alt="image" src="https://github.com/user-attachments/assets/22cd3619-6610-4ecc-aca7-724eae51467d" /> | 

We were falling back to the browser's serif font because we didn't include this font here. The same problem exists on https://tools.scientific-python.org/, https://learn.scientific-python.org/, https://numpy.org/, and https://scipy.org/, so it's widespread. I will prepare a follow-up PR for the theme to add the Lato font as a default.

cc: @stefanv

- [ ] ~The main subject relates to at least one project affiliated to the Scientific Python Ecosystem.~
- [ ] ~I have the right to publish the content under BSD 3-Clause License for the code and Creative Common CC-BY-4.0 License for the text.~
- [ ] ~Images have been compressed using a tool like `pngquant`.~
