### PR TITLE
Update to SPHT v0.23 release

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,20 +12,9 @@ markup:
       unsafe: true
     renderHooks:
       image:
-        enableDefault: true
+        useEmbedded: fallback
       link:
-        enableDefault: true
-
-outputFormats:
-  Atom:
-    mediaType: "application/atom"
-    baseName: "atom"
-    isPlainText: false
-
-mediaTypes:
-  application/atom:
-    suffixes:
-      - xml
+        useEmbedded: fallback
 
 frontmatter:
   date: [":filename", ":default"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build.environment]
   PYTHON_VERSION = "3.13"
-  HUGO_VERSION = "0.141.0"
-  DART_SASS_VERSION = "1.83.4"
+  HUGO_VERSION = "0.158.0"
+  DART_SASS_VERSION = "1.93.2"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 
 [build]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

For more information on how to submit:

https://blog.scientific-python.org/submitting/

Note that we are a team of volunteers; we appreciate your
patience during the review process. For more information:

https://blog.scientific-python.org/reviewing/

Again, thanks for contributing!
-->

Hi! This PR updates the website to use the v0.23 release of the Scientific Python Hugo Theme, which we've released today: https://github.com/scientific-python/scientific-python-hugo-theme/releases/tag/v0.23.

- [ ] ~The main subject relates to at least one project affiliated to the Scientific Python Ecosystem.~
- [ ] ~I have the right to publish the content under BSD 3-Clause License for the code and Creative Common CC-BY-4.0 License for the text.~
- [ ] ~Images have been compressed using a tool like `pngquant`.~

Checklist is N/A